### PR TITLE
Fix small things

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ The same can also be done with profiles just by using the profiles method instea
 
 ```ruby
 require 'spec_helper'
-require 'controlrepo'
+require 'onceover'
 Onceover::Controlrepo.profiles.each do |profile|
   describe profile do
     Onceover::Controlrepo.facts.each do |facts|
@@ -461,7 +461,7 @@ Just pass a hash to the `facts` method and it will return only the fact sets wit
 
 ```ruby
 require 'spec_helper'
-require 'controlrepo'
+require 'onceover'
 
 describe 'profile::windows_appserver' do
   Onceover::Controlrepo.facts({
@@ -492,7 +492,7 @@ Note that you will need to call the `roles` and `profiles` methods on the object
 I have included a couple of little rake tasks to help get you started with testing your control repos. Set them up by adding this to your `Rakefile`
 
 ```ruby
-require 'controlrepo/rake_tasks'
+require 'onceover/rake_tasks'
 ```
 
 The tasks are as follows:

--- a/lib/onceover/controlrepo.rb
+++ b/lib/onceover/controlrepo.rb
@@ -246,7 +246,8 @@ class Onceover
     def fixtures
       # Load up the Puppetfile using R10k
       puppetfile = R10K::Puppetfile.new(@root)
-      modules = puppetfile.load
+      fail 'Could not load Puppetfile' unless puppetfile.load
+      modules = puppetfile.modules
 
       # Iterate over everything and seperate it out for the sake of readability
       symlinks = []

--- a/lib/onceover/controlrepo.rb
+++ b/lib/onceover/controlrepo.rb
@@ -383,6 +383,8 @@ class Onceover
       Onceover::Controlrepo.init_write_file(generate_nodesets(repo),repo.nodeset_file)
       Onceover::Controlrepo.init_write_file(Onceover::Controlrepo.evaluate_template('pre_conditions_README.md.erb',binding),File.expand_path('./pre_conditions/README.md',repo.spec_dir))
       Onceover::Controlrepo.init_write_file(Onceover::Controlrepo.evaluate_template('factsets_README.md.erb',binding),File.expand_path('./factsets/README.md',repo.spec_dir))
+      Onceover::Controlrepo.init_write_file(Onceover::Controlrepo.evaluate_template('Rakefile.erb',binding),File.expand_path('./Rakefile',repo.root))
+      Onceover::Controlrepo.init_write_file(Onceover::Controlrepo.evaluate_template('Gemfile.erb',binding),File.expand_path('./Gemfile',repo.root))
 
       # Add .onceover to Gitignore
       gitignore_path = File.expand_path('.gitignore',repo.root)

--- a/lib/onceover/rake_tasks.rb
+++ b/lib/onceover/rake_tasks.rb
@@ -4,12 +4,16 @@ require 'pathname'
 @repo = nil
 @config = nil
 
+
+desc 'Writes a `fixtures.yml` file based on the Puppetfile'
 task :generate_fixtures do
   repo = Onceover::Controlrepo.new
   raise ".fixtures.yml already exits, we won't overwrite because we are scared" if File.exists?(File.expand_path('./.fixtures.yml',repo.root))
   File.write(File.expand_path('./.fixtures.yml',repo.root),repo.fixtures)
 end
 
+
+desc "Modifies your `hiera.yaml` to point at the hieradata relative to its position."
 task :hiera_setup do
   repo = Onceover::Controlrepo.new
   current_config = repo.hiera_config

--- a/lib/onceover/testconfig.rb
+++ b/lib/onceover/testconfig.rb
@@ -209,7 +209,7 @@ class Onceover
     end
 
     def write_rakefile(location, pattern)
-      File.write("#{location}/Rakefile",Onceover::Controlrepo.evaluate_template('Rakefile.erb',binding))
+      File.write("#{location}/Rakefile",Onceover::Controlrepo.evaluate_template('testconfig_Rakefile.erb',binding))
     end
 
     def write_spec_helper(location, repo)

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'onceover'
+gem 'beaker', '~> 2.0'
+

--- a/templates/Rakefile.erb
+++ b/templates/Rakefile.erb
@@ -1,6 +1,1 @@
-require 'puppetlabs_spec_helper/rake_tasks'
-
-desc "Run acceptance tests"
-RSpec::Core::RakeTask.new(:acceptance) do |t|
-  t.pattern = 'spec/acceptance'
-end
+require 'onceover/rake_tasks'

--- a/templates/testconfig_Rakefile.erb
+++ b/templates/testconfig_Rakefile.erb
@@ -1,0 +1,6 @@
+require 'puppetlabs_spec_helper/rake_tasks'
+
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
+end


### PR DESCRIPTION
This patch fixes a few minor problems:

* `rake -T` didn't display any tasks from `onceover/rake_tasks`; now it does
* `controlrepo` references in the README have been updated to `onceover`
* `onceover init` provides a onceover-friendly Gemfile and Rakefile if they don't exist already
* `R10k::Puppetfile` iterates with `.modules` now (`.load` returns a boolean)