### PR TITLE
Show puppet output

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,12 @@ This will do the following things:
 
 When using this gem adding your own spec tests is exactly the same as if you were to add them to a module, simply create them under `spec/{classes,defines,etc.}` in the Controlrepo and they will be run like normal, along with all of the `it { should compile }` tests.
 
+### Exposing Puppet output
+
+If you want to see Puppet's output, you can set the `SHOW_PUPPET_OUTPUT` environment variable to `true`, eg:
+
+`SHOW_PUPPET_OUTPUT=true onceover run spec`
+
 ## Acceptance testing
 
 Acceptance testing works in much the same way as spec testing except that it requires a nodeset file along with `onceover.yaml`

--- a/templates/spec_helper.rb.erb
+++ b/templates/spec_helper.rb.erb
@@ -14,4 +14,8 @@ RSpec.configure do |c|
   c.hiera_config = '<%= environmentpath %>/production/hiera.yaml'
   c.manifest = '<%= repo.temp_manifest %>'
   ENV['STRICT_VARIABLES'] = '<%= self.strict_variables %>'
+<% if ENV['SHOW_PUPPET_OUTPUT'].downcase == 'true' %>
+  Puppet::Util::Log.level = :debug
+  Puppet::Util::Log.newdestination(:console)
+<% end -%>
 end

--- a/templates/spec_helper.rb.erb
+++ b/templates/spec_helper.rb.erb
@@ -14,7 +14,7 @@ RSpec.configure do |c|
   c.hiera_config = '<%= environmentpath %>/production/hiera.yaml'
   c.manifest = '<%= repo.temp_manifest %>'
   ENV['STRICT_VARIABLES'] = '<%= self.strict_variables %>'
-<% if ENV['SHOW_PUPPET_OUTPUT'].downcase == 'true' %>
+<% if ENV['SHOW_PUPPET_OUTPUT'] and ENV['SHOW_PUPPET_OUTPUT'].downcase == 'true' %>
   Puppet::Util::Log.level = :debug
   Puppet::Util::Log.newdestination(:console)
 <% end -%>


### PR DESCRIPTION
This PR lets you expose Puppet's output to the console by setting the environment variable `SHOW_PUPPET_OUTPUT` to `true`