### PR TITLE
support for puppetbox -- aceptance_alpha

### DIFF
--- a/lib/onceover/cli/run.rb
+++ b/lib/onceover/cli/run.rb
@@ -77,6 +77,8 @@ This includes deploying using r10k and running all custom tests.
             usage 'acceptance_alpha'
             summary 'Runs acceptance tests (alpha version)'
 
+            optional :k,  :keep_test_system, 'keep the test system active after testing (to debug failed tests)'
+
             run do |opts, args, cmd|
               repo = Onceover::Controlrepo.new(opts)
               runner = Onceover::Runner.new(repo,Onceover::TestConfig.new(repo.onceover_yaml,opts),:acceptance_alpha)

--- a/lib/onceover/cli/run.rb
+++ b/lib/onceover/cli/run.rb
@@ -77,7 +77,9 @@ This includes deploying using r10k and running all custom tests.
             usage 'acceptance_alpha'
             summary 'Runs acceptance tests (alpha version)'
 
-            optional :k,  :keep_test_system, 'keep the test system active after testing (to debug failed tests)'
+            optional :k,  :keep_test_system, 'Keep the test system active after testing (to debug failed tests)'
+            optional :n,  :only_node, 'Only run tests on this node'
+            optional :c,  :only_class, 'Only run this one class'
 
             run do |opts, args, cmd|
               repo = Onceover::Controlrepo.new(opts)

--- a/lib/onceover/cli/run.rb
+++ b/lib/onceover/cli/run.rb
@@ -68,6 +68,28 @@ This includes deploying using r10k and running all custom tests.
           end
         end
       end
+
+
+      class AcceptanceAlpha
+        def self.command
+          @cmd ||= Cri::Command.define do
+            name 'acceptance_alpha'
+            usage 'acceptance_alpha'
+            summary 'Runs acceptance tests (alpha version)'
+
+            run do |opts, args, cmd|
+              repo = Onceover::Controlrepo.new(opts)
+              runner = Onceover::Runner.new(repo,Onceover::TestConfig.new(repo.onceover_yaml,opts),:acceptance_alpha)
+              runner.prepare!
+              if ! runner.run_acceptance_alpha!
+                # cause a non-zero exit
+                abort("There are acceptance tests failures!")
+              end
+            end
+          end
+        end
+      end
+
     end
   end
 end
@@ -76,3 +98,4 @@ end
 Onceover::CLI.command.add_command(Onceover::CLI::Run.command)
 Onceover::CLI::Run.command.add_command(Onceover::CLI::Run::Spec.command)
 Onceover::CLI::Run.command.add_command(Onceover::CLI::Run::Acceptance.command)
+Onceover::CLI::Run.command.add_command(Onceover::CLI::Run::AcceptanceAlpha.command)

--- a/lib/onceover/runner.rb
+++ b/lib/onceover/runner.rb
@@ -127,8 +127,6 @@ class Onceover
         test.nodes.each { |node|
           # test_suite[node.name] = {}
           test.classes.each { |puppet_class|
-            puts "only node #{only_node} vs #{node.name}"
-            puts "only class #{only_class} vs #{puppet_class.name}"
             if  (! only_node or only_node == node.name) and
                 (! only_class or only_class == puppet_class.name)
               logger.info "Requesting testing on #{node.name} for #{puppet_class.name}"

--- a/onceover.gemspec
+++ b/onceover.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'table_print', '>= 1.0.0'
   s.add_runtime_dependency 'versionomy', '>= 0.5.0'
   s.add_runtime_dependency 'rspec_junit_formatter', '>= 0.2.0'
+  s.add_runtime_dependency 'puppetbox', '~> 0.4'
 end


### PR DESCRIPTION
Addresses #93 

Builds on previously linked example to work to fix bugs, be minimally invasive and provide better error messages.  Run onceover with --debug to get a ton of useful debugging information

How to run:
```
onceover run acceptance_alpha
```

Missing/todo:
* documentation
* publish the vagrant boxes (they need a recent puppet + guestbox additions)

