### PR TITLE
Syntax and style tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,684 @@
+AllCops:
+  Include:
+    - 'lib/**/*.rb'
+    - 'ext/**/*.rb'
+  Exclude:
+    - '**/*.erb'
+    - 'acceptance/**/*'
+    - 'autotest/**/*'
+    - 'spec/**/*'
+    - 'tasks/**/*'
+    - 'lib/puppet/vendor/**/*'
+    - 'lib/puppet/parser/parser.rb'
+    - 'lib/puppet/pops/parser/eparser.rb'
+    - 'lib/puppet/external/nagios/parser.rb'
+    - 'lib/puppet/module_tool/skeleton/**/*'
+    - 'lib/semantic_puppet/dependency/module_release.rb'
+
+Lint/ConditionPosition:
+  Enabled: true
+
+Lint/ElseLayout:
+  Enabled: true
+
+Lint/UnreachableCode:
+  Enabled: true
+
+Lint/UselessComparison:
+  Enabled: true
+
+# MAYBE useful - no return inside ensure block.
+Lint/EnsureReturn:
+  Enabled: false
+
+# MAYBE useful - errors when rescue {} happens.
+Lint/HandleExceptions:
+  Enabled: false
+
+# MAYBE useful - catches while 1
+Lint/LiteralInCondition:
+  Enabled: false
+
+Lint/ShadowingOuterLocalVariable:
+  Enabled: true
+
+# Can catch complicated strings.
+Lint/LiteralInInterpolation:
+  Enabled: true
+
+
+# DISABLED really useless. Detects return as last statement.
+Style/RedundantReturn:
+  Enabled: false
+
+# Disabled. Throws an error trying to run.
+Style/RedundantParentheses:
+  Enabled: false
+
+# DISABLED since the instances do not seem to indicate any specific errors.
+Lint/AmbiguousOperator:
+  Enabled: false
+
+# DISABLED since for all the checked, we are basically checking nil
+# TODO: Change the checking so that if the variable being assigned to has
+# a value ALREADY, then raise an error.
+Lint/AssignmentInCondition:
+  Enabled: false
+
+# DISABLED - not useful
+Style/SpaceBeforeComment:
+  Enabled: false
+
+# DISABLED - not useful
+Style/HashSyntax:
+  Enabled: false
+
+# USES: as shortcut for non nil&valid checking a = x() and a.empty?
+# DISABLED - not useful
+Style/AndOr:
+  Enabled: false
+
+# DISABLED - not useful
+Style/RedundantSelf:
+  Enabled: false
+
+# DISABLED - not useful
+Metrics/MethodLength:
+  Enabled: false
+
+# DISABLED - not useful
+Style/WhileUntilModifier:
+  Enabled: false
+
+# DISABLED - the offender is just haskell envy
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+
+# DISABLED
+Lint/Eval:
+  Enabled: false
+# DISABLED
+Lint/BlockAlignment:
+  Enabled: false
+
+# DISABLED
+Lint/DefEndAlignment:
+  Enabled: false
+
+# DISABLED
+Lint/EndAlignment:
+  Enabled: false
+
+# DISABLED
+Lint/DeprecatedClassMethods:
+  Enabled: false
+
+# DISABLED
+Lint/Loop:
+  Enabled: false
+
+# DISABLED
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: false
+
+Lint/RescueException:
+  Enabled: false
+
+Lint/StringConversionInInterpolation:
+  Enabled: false
+
+Lint/UnusedBlockArgument:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+# DISABLED - TODO
+Lint/UselessAccessModifier:
+  Enabled: false
+
+# DISABLED - TODO
+Lint/UselessAssignment:
+  Enabled: false
+
+# DISABLED - TODO
+Lint/Void:
+  Enabled: false
+
+Style/AccessModifierIndentation:
+  Enabled: false
+
+Style/AccessorMethodName:
+  Enabled: false
+
+Style/Alias:
+  Enabled: false
+
+Style/AlignArray:
+  Enabled: false
+
+Style/AlignHash:
+  Enabled: false
+
+Style/AlignParameters:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false
+
+Style/AsciiComments:
+  Enabled: false
+
+Style/Attr:
+  Enabled: false
+
+Style/BracesAroundHashParameters:
+  Enabled: false
+
+Style/CaseEquality:
+  Enabled: false
+
+Style/CaseIndentation:
+  Enabled: false
+
+Style/CharacterLiteral:
+  Enabled: false
+
+Style/ClassAndModuleCamelCase:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/ClassCheck:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Style/ClassMethods:
+  Enabled: false
+
+Style/ClassVars:
+  Enabled: false
+
+Style/WhenThen:
+  Enabled: false
+
+
+# DISABLED - not useful
+Style/WordArray:
+  Enabled: false
+
+Style/UnneededPercentQ:
+  Enabled: false
+
+Style/Tab:
+  Enabled: false
+
+Style/SpaceBeforeSemicolon:
+  Enabled: false
+
+Style/TrailingBlankLines:
+  Enabled: false
+
+Style/SpaceInsideBlockBraces:
+  Enabled: false
+
+Style/SpaceInsideBrackets:
+  Enabled: false
+
+Style/SpaceInsideHashLiteralBraces:
+  Enabled: false
+
+Style/SpaceInsideParens:
+  Enabled: false
+
+Style/LeadingCommentSpace:
+  Enabled: false
+
+Style/SpaceAfterColon:
+  Enabled: false
+
+Style/SpaceAfterComma:
+  Enabled: false
+
+Style/SpaceAroundKeyword:
+  Enabled: false
+
+Style/SpaceAfterMethodName:
+  Enabled: false
+
+Style/SpaceAfterNot:
+  Enabled: false
+
+Style/SpaceAfterSemicolon:
+  Enabled: false
+
+Style/SpaceAroundEqualsInParameterDefault:
+  Enabled: false
+
+Style/SpaceAroundOperators:
+  Enabled: false
+
+Style/SpaceBeforeBlockBraces:
+  Enabled: false
+
+Style/SpaceBeforeComma:
+  Enabled: false
+
+
+Style/CollectionMethods:
+  Enabled: false
+
+Style/CommentIndentation:
+  Enabled: false
+
+Style/ColonMethodCall:
+  Enabled: false
+
+Style/CommentAnnotation:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Style/ConstantName:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/DefWithParentheses:
+  Enabled: false
+
+Style/DeprecatedHashMethods:
+  Enabled: false
+
+Style/DotPosition:
+  Enabled: false
+
+# DISABLED - used for converting to bool
+Style/DoubleNegation:
+  Enabled: false
+
+Style/EachWithObject:
+  Enabled: false
+
+Style/EmptyLineBetweenDefs:
+  Enabled: false
+
+Style/IndentArray:
+  Enabled: false
+
+Style/IndentHash:
+  Enabled: false
+
+Style/IndentationConsistency:
+  Enabled: false
+
+Style/IndentationWidth:
+  Enabled: false
+
+Style/EmptyLines:
+  Enabled: false
+
+Style/EmptyLinesAroundAccessModifier:
+  Enabled: false
+
+Style/EmptyLiteral:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false
+
+Style/MethodCallParentheses:
+  Enabled: false
+
+Style/MethodDefParentheses:
+  Enabled: false
+
+Style/LineEndConcatenation:
+  Enabled: false
+
+Style/TrailingWhitespace:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+Style/GlobalVars:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/MultilineIfThen:
+  Enabled: false
+
+Style/NegatedIf:
+  Enabled: false
+
+Style/NegatedWhile:
+  Enabled: false
+
+Style/Next:
+  Enabled: false
+
+Style/SingleLineBlockParams:
+  Enabled: false
+
+Style/SingleLineMethods:
+  Enabled: false
+
+Style/SpecialGlobalVars:
+  Enabled: false
+
+
+Style/TrivialAccessors:
+  Enabled: false
+
+Style/UnlessElse:
+  Enabled: false
+
+Style/VariableInterpolation:
+  Enabled: false
+
+Style/VariableName:
+  Enabled: false
+
+Style/WhileUntilDo:
+  Enabled: false
+
+Style/EvenOdd:
+  Enabled: false
+
+Style/FileName:
+  Enabled: false
+
+Style/For:
+  Enabled: false
+
+Style/Lambda:
+  Enabled: false
+
+Style/MethodName:
+  Enabled: false
+
+Style/MultilineTernaryOperator:
+  Enabled: false
+
+Style/NestedTernaryOperator:
+  Enabled: false
+
+Style/NilComparison:
+  Enabled: false
+
+Style/FormatString:
+  Enabled: false
+
+Style/MultilineBlockChain:
+  Enabled: false
+
+Style/Semicolon:
+  Enabled: false
+
+Style/SignalException:
+  Enabled: false
+
+Style/NonNilCheck:
+  Enabled: false
+
+Style/Not:
+  Enabled: false
+
+Style/NumericLiterals:
+  Enabled: false
+
+Style/OneLineConditional:
+  Enabled: false
+
+Style/OpMethod:
+  Enabled: false
+
+Style/ParenthesesAroundCondition:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
+
+Style/PerlBackrefs:
+  Enabled: false
+
+Style/PredicateName:
+  Enabled: false
+
+Style/RedundantException:
+  Enabled: false
+
+Style/SelfAssignment:
+  Enabled: false
+
+Style/Proc:
+  Enabled: false
+
+Style/RaiseArgs:
+  Enabled: false
+
+Style/RedundantBegin:
+  Enabled: false
+
+Style/RescueModifier:
+  Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Lint/RequireParentheses:
+  Enabled: false
+
+Style/SpaceBeforeFirstArg:
+  Enabled: false
+
+Style/ModuleFunction:
+  Enabled: false
+
+Lint/Debugger:
+  Enabled: false
+
+Style/IfWithSemicolon:
+  Enabled: false
+
+Style/Encoding:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Style/SymbolProc:
+  Enabled: false
+
+Style/SpaceInsideRangeLiteral:
+  Enabled: false
+
+Style/InfiniteLoop:
+  Enabled: false
+
+Style/BarePercentLiterals:
+  Enabled: false
+
+Style/PercentQLiterals:
+  Enabled: false
+
+Style/MultilineBlockLayout:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Style/MutableConstant:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Enabled: false
+
+Style/EmptyLinesAroundClassBody:
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Style/ExtraSpacing:
+  Enabled: false
+
+Style/EmptyLinesAroundBlockBody:
+  Enabled: false
+
+Style/EmptyLinesAroundModuleBody:
+  Enabled: false
+
+Style/MultilineOperationIndentation:
+  Enabled: false
+
+Style/EmptyElse:
+  Enabled: false
+
+Style/StringLiteralsInInterpolation:
+  Enabled: false
+
+Style/MultilineMethodCallIndentation:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Style/EmptyLinesAroundMethodBody:
+  Enabled: false
+
+Lint/IneffectiveAccessModifier:
+  Enabled: false
+
+Performance/StringReplacement:
+  Enabled: false
+
+Style/ClosingParenthesisIndentation:
+  Enabled: false
+
+Style/UnneededInterpolation:
+  Enabled: false
+
+Style/ElseAlignment:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/FirstParameterIndentation:
+  Enabled: false
+
+Style/IfInsideElse:
+  Enabled: false
+
+Style/IndentAssignment:
+  Enabled: false
+
+Style/SpaceAroundBlockParameters:
+  Enabled: false
+
+Style/ParallelAssignment:
+  Enabled: false
+
+Performance/RedundantBlockCall:
+  Enabled: false
+
+Style/IdenticalConditionalBranches:
+  Enabled: false
+
+Performance/RedundantMatch:
+  Enabled: false
+
+Style/CommandLiteral:
+  Enabled: false
+
+Performance/Casecmp:
+  Enabled: false
+
+Lint/NestedMethodDefinition:
+  Enabled: false
+
+Style/SpaceInsideStringInterpolation:
+  Enabled: false
+
+Performance/RedundantMerge:
+  Enabled: false
+
+Performance/ReverseEach:
+  Enabled: false
+
+Style/NestedModifier:
+  Enabled: false
+
+Lint/NonLocalExitFromIterator:
+  Enabled: false
+
+Performance/Count:
+  Enabled: false
+
+Style/NestedParenthesizedCalls:
+  Enabled: false
+
+Style/RescueEnsureAlignment:
+  Enabled: false
+
+Lint/DuplicateMethods:
+  Enabled: false
+
+Performance/RangeInclude:
+  Enabled: false
+
+Style/TrailingUnderscoreVariable:
+  Enabled: false
+
+Lint/LiteralInInterpolation:
+  Enabled: false
+
+Performance/DoubleStartEndWith:
+  Enabled: false
+
+Performance/RedundantSortBy:
+  Enabled: false
+
+Performance/TimesMap:
+  Enabled: false
+
+Style/InitialIndentation:
+  Enabled: false
+
+Style/StructInheritance:
+  Enabled: false
+
+Style/SymbolLiteral:
+  Enabled: false
+
+Style/IfUnlessModifierOfIfUnless:
+  Enabled: false
+
+Style/ZeroLengthPredicate:
+  Enabled: false
+
+

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 gem 'rubygems-tasks'
 gem 'git'
 gem 'rake'
-gem 'rubocop'
+gem 'rubocop', "~> 0.39.0" # in line with puppet gem and its rubocop.yml we're using
+
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
-
 gem 'rubygems-tasks'
 gem 'git'
 gem 'rake'
+gem 'rubocop'
+

--- a/README.md
+++ b/README.md
@@ -628,6 +628,16 @@ fixtures:
 
 Notice that the symlinks are not the ones that we provided in `environment.conf`? This is because the rake task will go into each of directories, find the modules and create a symlink for each of them (This is what rspec expects).
 
+## Developing Onceover
+
+Install gem dependencies:
+
+`bundle install`
+
+Execute tests
+
+`bundle exec rake test`
+
 ## Contributors
 
 Cheers to all of those who helped out:

--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ Install gem dependencies:
 
 Execute tests
 
-`bundle exec rake test`
+`bundle exec rake`
 
 ## Contributors
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,23 @@
 require 'rubygems/tasks'
 Gem::Tasks.new
 
-task test: :rubocop
+task default: :test
+
+task test: [:syntax, :rubocop, ]
+
+task :syntax do
+  paths = ['lib',]
+  require 'find'
+  Find.find(*paths) do |path|
+    next unless path =~ /\.rb$/
+    sh "ruby -cw #{path} > /dev/null"
+  end
+end
 
 task :rubocop do
-  sh 'rubocop'
+  require 'rubocop'
+  cli = RuboCop::CLI.new
+  exit_code = cli.run(%w(--display-cop-names --format simple))
+  raise "RuboCop detected offenses" if exit_code != 0
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,9 @@
 require 'rubygems/tasks'
 Gem::Tasks.new
+
+task test: :rubocop
+
+task :rubocop do
+  sh 'rubocop'
+end
+


### PR DESCRIPTION
adds rake tasks:
- `syntax` - checks ruby syntax of all .rb files in onceover lib dir
- `rubocop` - checks conformance with ruby style guide with customisations from the puppet gem rubocop config
- `test` - which just calls the above two tasks
