### PR TITLE
only skip r10k when using --skip_r10k

### DIFF
--- a/lib/onceover/runner.rb
+++ b/lib/onceover/runner.rb
@@ -11,10 +11,8 @@ class Onceover
     end
 
     def prepare!
-      unless @config.skip_r10k
-        # Deploy the puppetfile
-        @config.r10k_deploy_local(@repo)
-      end
+      # Deploy the control repo
+      @config.deploy_local(@repo, {:skip_r10k => @config.skip_r10k})
 
       # Remove the entire spec directory to make sure we have
       # all the latest tests

--- a/lib/onceover/testconfig.rb
+++ b/lib/onceover/testconfig.rb
@@ -157,9 +157,12 @@ class Onceover
       puppetcode.join("\n")
     end
 
-    def r10k_deploy_local(repo = Onceover::Controlrepo.new)
+    def deploy_local(repo = Onceover::Controlrepo.new, opts = {})
       require 'onceover/controlrepo'
       require 'pathname'
+
+      skip_r10k = opts[:skip_r10k] || false
+
       if repo.tempdir == nil
         repo.tempdir = Dir.mktmpdir('r10k')
       else
@@ -207,7 +210,7 @@ class Onceover
       FileUtils.rm_rf(temp_controlrepo)
 
       # Pull the trigger! If it's not already been pulled
-      if repo.tempdir
+      if repo.tempdir and not skip_r10k
         if File.directory?(repo.tempdir)
           # TODO: Change this to call out to r10k directly to do this
           # Probably something like:

--- a/lib/onceover/testconfig.rb
+++ b/lib/onceover/testconfig.rb
@@ -216,9 +216,11 @@ class Onceover
           # Probably something like:
           # R10K::Settings.global_settings.evaluate(with_overrides)
           # R10K::Action::Deploy::Environment
-          Dir.chdir("#{repo.tempdir}/#{repo.environmentpath}/production") do
-            logger.debug "Runing r10k puppetfile install --verbose --color --puppetfile #{repo.puppetfile} from #{repo.tempdir}/#{repo.environmentpath}/production"
-            system("r10k puppetfile install --verbose --color --puppetfile #{repo.puppetfile}")
+          prod_dir = "#{repo.tempdir}/#{repo.environmentpath}/production"
+          Dir.chdir(prod_dir) do
+            install_cmd = "r10k puppetfile install --verbose --color"
+            logger.debug "Running #{install_cmd} from #{prod_dir}"
+            system(install_cmd)
           end
         else
           raise "#{repo.tempdir} is not a directory"


### PR DESCRIPTION
prior to this, --skip_r10k would skip updating the puppet code in the control repo as well as r10k, clearly not what you want 

Note that this PR builds on #125 so give that one a look first. failing that, i can rebase off master if necessary