### PR TITLE
Fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Gemfile.lock
 /.bin
 /.ruby-version
 
-#Vim
+# Vim
 /.projections.json
+/tags
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 *.gem
 Gemfile.lock
+/spec/fixtures/puppet_controlrepo
 
 # Bundler / Rbenv
 /.bundle

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "spec/fixtures/puppet_controlrepo"]
-	path = spec/fixtures/puppet_controlrepo
-	url = https://github.com/dylanratcliffe/puppet_controlrepo.git
-	branch = production

--- a/README.md
+++ b/README.md
@@ -634,10 +634,6 @@ Install gem dependencies:
 
 `bundle install`
 
-Clone the submodules
-
-`git submodule init && git submodule update --recursive`
-
 Execute tests
 
 `bundle exec rake`

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ end
 
 task default: :test
 
-task test: [:syntax, :rubocop, :spec]
+task test: [:syntax, :rubocop, :fixtures, :spec]
 
 task :syntax do
   paths = ['lib',]
@@ -25,3 +25,12 @@ task :rubocop do
   exit_code = cli.run(%w(--display-cop-names --format simple))
   raise "RuboCop detected offenses" if exit_code != 0
 end
+
+task :fixtures do
+   clone_controlrepo_cmd = 'git clone https://github.com/dylanratcliffe/puppet_controlrepo.git spec/fixtures/puppet_controlrepo'
+  unless File.directory?('spec/fixtures/puppet_controlrepo')
+    system clone_controlrepo_cmd
+    raise "Couldn't clone controlrepo to fixtures directory" unless $?.success?
+  end
+end
+


### PR DESCRIPTION
This proposal is to simplify development process.

git submodules in my opinion are too strict, more flexible solution is to manually manage (git clone/checkout/branch commands) external control repo project. In this way we can easy choose what version of repo project we want to use for our fixtures. For example if we have different control repo for different puppets (4.x, 5.x) or if we want to use branches to manage different control's repo configuration (basic, simple, medium complex, very complex).