### PR TITLE
Acceptance tests (ready to merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ repo.role_regex = /.*/ # Tells the class how to find roles, will be applied to r
 repo.profile_regex = /.*/ # Tells the class how to find profiles, will be applied to repo.classes
 ```
 
-Note that you will need to call the `roles` and `profiles` methods on the object you just instantiated, not the main class e.g. `repo.roles` not Onceover::Controlrepo.roles`
+Note that you will need to call the `roles` and `profiles` methods on the object you just instantiated, not the main class e.g. `repo.roles` not Onceover::Controlrepo.roles
 
 ### Rake tasks
 

--- a/features/help.feature
+++ b/features/help.feature
@@ -1,4 +1,4 @@
-Feature: Run basic function of Onceover
+Feature: Get help about Onceover's features, commands and commands' parameters
   I would like to use executable file to run Onceover and read help
 
   Background:

--- a/features/run.feature
+++ b/features/run.feature
@@ -6,8 +6,14 @@ Feature: Run rspec and acceptance test suits
   Background:
     Given onceover executable
 
- Scenario: Run full set of rspec tests
+ Scenario: Run correct spec tests
     Given initialized control repo "controlrepo_basic"
     When I run onceover command "run spec"
     Then I should not see any errors
+
+ Scenario: Run spec tests with misspelled module in Puppetfile
+    Given initialized control repo "controlrepo_basic"
+    And in Puppetfile is misspelled module's name
+    When I run onceover command "run spec"
+    Then I should see error with message pattern "The module acma-not_exists does not exists"
 

--- a/features/run.feature
+++ b/features/run.feature
@@ -1,0 +1,13 @@
+Feature: Run rspec and acceptance test suits
+  Onceover should allow to run rspec and acceptance test for all profvile and role classes
+  or for any part of them. Use should set if he wants to see only summary of tests or full
+  log info.
+
+  Background:
+    Given onceover executable
+
+ Scenario: Run full set of rspec tests
+    Given initialized control repo "controlrepo_basic"
+    When I run onceover command "run spec"
+    Then I should not see any errors
+

--- a/features/run.feature
+++ b/features/run.feature
@@ -15,5 +15,5 @@ Feature: Run rspec and acceptance test suits
     Given initialized control repo "controlrepo_basic"
     And in Puppetfile is misspelled module's name
     When I run onceover command "run spec"
-    Then I should see error with message pattern "The module acma-not_exists does not exists"
+    Then I should see error with message pattern "The module acme-not_exists does not exist"
 

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -1,12 +1,13 @@
 Given /^onceover executable$/ do
-  @cmd = Command.new
+  @cmd = Command_Helper.new
 end
 
 Given(/^control repo "([^"]*)"$/) do |controlrepo_name|
-  @cmd.controlrepo = controlrepo_name
-  FileUtils.rm_rf "tmp/tests/#{controlrepo_name}"
-  FileUtils.mkdir_p 'tmp/tests'
-  FileUtils.cp_r "spec/fixtures/#{controlrepo_name}", 'tmp/tests'
+  @repo = ControlRepo_Helper.new( controlrepo_name )
+  @cmd.controlrepo = @repo
+  FileUtils.rm_rf @repo.root_folder
+  FileUtils.mkdir_p 'tmp'
+  FileUtils.cp_r "spec/fixtures/#{controlrepo_name}", 'tmp'
 end
 
 Given(/^initialized control repo "([^"]*)"$/) do |controlrepo_name|
@@ -16,13 +17,7 @@ end
 
 Given(/^control repo "([^"]*)" without "([^"]*)"$/) do |controlrepo_name, filename|
   step %Q(control repo "#{controlrepo_name}")
-  controlrepo_path = "tmp/tests/#{controlrepo_name}"
-  FileUtils.rm_rf( controlrepo_path + "/#{filename}" )
-end
-
-
-Then(/^I should see all tests pass$/) do
-  pending # Write code here that turns the phrase above into concrete actions
+  FileUtils.rm_rf "#{@repo.root_folder}/#{filename}"
 end
 
 When /^I run onceover command "([^"]*)"$/  do |command|
@@ -50,17 +45,6 @@ Then(/^I should see error with message pattern "([^"]*)"$/) do |err_msg_regexp|
   expect(@cmd.output.match err_msg_regexp).to_not be nil
 end
 
-Then(/^I should see generated all necessary files and folders$/) do
-  controlrepo_path = "tmp/tests/controlrepo_basic/"
-  files = [ 'spec/onceover.yaml', 'Rakefile', 'Gemfile' ].map { |x| controlrepo_path + x }
-  folders = [ 'spec/factsets', 'spec/pre_conditions'].map! { |x| controlrepo_path + x}
+Given(/^in Puppetfile is misspelled module's name$/) do
 
-  files.each do |file|
-    puts file
-    expect( File.exist? file ).to be true
-  end
-  folders.each do |folder|
-    puts folder
-    expect( Dir.exist? folder ).to be true
-  end
 end

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -9,11 +9,17 @@ Given(/^control repo "([^"]*)"$/) do |controlrepo_name|
   FileUtils.cp_r "spec/fixtures/#{controlrepo_name}", 'tmp/tests'
 end
 
+Given(/^initialized control repo "([^"]*)"$/) do |controlrepo_name|
+  step %Q(control repo "#{controlrepo_name}")
+  step %Q(I run onceover command "init")
+end
+
 Given(/^control repo "([^"]*)" without "([^"]*)"$/) do |controlrepo_name, filename|
   step %Q(control repo "#{controlrepo_name}")
   controlrepo_path = "tmp/tests/#{controlrepo_name}"
   FileUtils.rm_rf( controlrepo_path + "/#{filename}" )
 end
+
 
 Then(/^I should see all tests pass$/) do
   pending # Write code here that turns the phrase above into concrete actions

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -46,5 +46,5 @@ Then(/^I should see error with message pattern "([^"]*)"$/) do |err_msg_regexp|
 end
 
 Given(/^in Puppetfile is misspelled module's name$/) do
-
+  @repo.add_line_to_puppetfile %Q(mod "acme/not_exists", "7.7.7")
 end

--- a/features/step_definitions/init.rb
+++ b/features/step_definitions/init.rb
@@ -1,0 +1,13 @@
+Then(/^I should see generated all necessary files and folders$/) do
+  files = [ 'spec/onceover.yaml', 'Rakefile', 'Gemfile' ].map { |x| @repo.root_folder + x }
+  folders = [ 'spec/factsets', 'spec/pre_conditions'].map! { |x| @repo.root_folder + x}
+
+  files.each do |file|
+    puts file
+    expect( File.exist? file ).to be true
+  end
+  folders.each do |folder|
+    puts folder
+    expect( Dir.exist? folder ).to be true
+  end
+end

--- a/features/support/command_helper.rb
+++ b/features/support/command_helper.rb
@@ -1,6 +1,6 @@
 require "open3"
 
-class Command
+class Command_Helper
 
   attr_reader(:output, :result)
 
@@ -11,18 +11,20 @@ class Command
   end
 
   def run
-    controlrepo_param = @controlrepo ? "--path tmp/tests/#{@controlrepo}" : ''
-    full_cmd = "#{@executable} #{@command} #{controlrepo_param}"
-    @output, @result = Open3.capture2e full_cmd
+    @output, @result = Open3.capture2e generate_command
   end
 
   def success?
     return @result.success?
   end
 
-  def to_s
-    controlrepo_param = @controlrepo ? "--path tmp/tests/#{@controlrepo}" : ''
+  def generate_command
+    controlrepo_param = @controlrepo ? "--path #{@controlrepo.root_folder}" : ''
     return "#{@executable} #{@command} #{controlrepo_param}"
+  end
+
+  def to_s
+    return generate_command
   end
 
 end

--- a/features/support/controlrepo_helper.rb
+++ b/features/support/controlrepo_helper.rb
@@ -1,0 +1,12 @@
+class ControlRepo_Helper
+
+  def initialize( name )
+    @name = name
+    @tmp_folder = 'tmp/'
+  end
+
+  def root_folder
+    return @tmp_folder + @name + '/'
+  end
+
+end

--- a/features/support/controlrepo_helper.rb
+++ b/features/support/controlrepo_helper.rb
@@ -9,4 +9,8 @@ class ControlRepo_Helper
     return @tmp_folder + @name + '/'
   end
 
+  def add_line_to_puppetfile( line )
+    open(root_folder + 'Puppetfile', 'a') { |f| f.puts line }
+  end
+
 end

--- a/lib/onceover/testconfig.rb
+++ b/lib/onceover/testconfig.rb
@@ -221,6 +221,7 @@ class Onceover
             install_cmd = "r10k puppetfile install --verbose --color --puppetfile #{repo.puppetfile}"
             logger.debug "Running #{install_cmd} from #{prod_dir}"
             system(install_cmd)
+            raise 'r10k could not install all required modules' unless $?.success?
           end
         else
           raise "#{repo.tempdir} is not a directory"

--- a/lib/onceover/testconfig.rb
+++ b/lib/onceover/testconfig.rb
@@ -147,7 +147,7 @@ class Onceover
 
     def pre_condition
       # Read all the pre_conditions and return the string
-      spec_dir = Onceover::Controlrepo.new.spec_dir
+      spec_dir = Onceover::Controlrepo.new(@opts).spec_dir
       puppetcode = []
       Dir["#{spec_dir}/pre_conditions/*.pp"].each do |condition_file|
         logger.debug "Reading pre_conditions from #{condition_file}"

--- a/spec/fixtures/controlrepo_basic/Puppetfile
+++ b/spec/fixtures/controlrepo_basic/Puppetfile
@@ -1,10 +1,10 @@
 forge "http://forge.puppetlabs.com"
+#
+# I want to download some modules to check if r10k feature in Onceover works correctly.
+#
 
-# Modules from the Puppet Forge
 # Versions should be updated to be the latest at the time you start
-#mod "puppetlabs/inifile",     '1.5.0'
-#mod "puppetlabs/stdlib",      '4.11.0'
-#mod "puppetlabs/concat",      '2.1.0'
+mod "puppetlabs/stdlib",      '4.11.0'
 
 # Modules from Git
 # Examples: https://github.com/puppetlabs/r10k/blob/master/doc/puppetfile.mkd#examples


### PR DESCRIPTION
This is summary PR with all acceptance tests I wrote. Part of it was in PR #138 . But I want to split it to chunks to faster review process... I hope ;) 

Short explanation adopted method. Acceptance tests are wrote in Gherkin with Cucumber engine. I use standard Cucumber (for Ruby) folder's convention, so tests are in  **features**, helper metods/classes/environments are in **features/support**, code of backend is in **features/step_definitions". There are two additional folders I used **spec/fixtures** to keep (suprise, suprise) fixtures for tests and **tmp** for runtime files.

All cucumber features so far are Onceover commands, I show some outputs, it helps to debug but I think in future this should be toogle from command line (show scenarios and steps with and without verbose output). I decide to not create many control repos but use one basic and if test required, modifie it, for example remove some file or add some line to file.

Full set of test can be run with **bundle exec rake cucumber_acceptance_tests**, single feature can be test by **bundle exec cucumber features/XXX.feature**, single scenario can be run by **bundle exec cucumber -n "name of scenario"**. I think we can extend rake to cover all this scenarios. All commands should be run from main gem's folder, I use relative paths in steps (maybe it should be changed).

Additional to steps I added two helpers Command_Helper and Repo_Helper.