### PR TITLE
[WIP] Use facterdb as main source of facts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 *.gem
 Gemfile.lock
+.byebug*
 
 # Bundler / Rbenv
 /.bundle

--- a/features/show.feature
+++ b/features/show.feature
@@ -1,6 +1,6 @@
 Feature: Show the state of things
   For a correct controlrepo I would like to see details of the Puppetfile and
-  the things that have been detedted by onceover in the controlrepo.
+  the things that have been detected by onceover in the controlrepo.
 
   Background:
     Given onceover executable

--- a/onceover.gemspec
+++ b/onceover.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |s|
   # Development
   s.add_development_dependency 'rubocop', '~> 0.49.0'
   s.add_development_dependency 'rubygems-tasks', '~> 0.2.0'
-  s.add_development_dependency 'pry', '~> 0.10.0'
   s.add_development_dependency 'cucumber', '~> 2.0'
+  s.add_development_dependency 'pry-byebug', '~> 3.0'
+
 end


### PR DESCRIPTION
This PR is open only to start discuss about using facts in onceover. I will add another commits when we agree how this feature should look like.

Now all facts are delivered by json files which are in **factsets** folder or could be given in command line (--facts_dir, --facts_files). Facts are close connected with node name.

New way of deliver would be very similar, facts will be delivered by facterdb and connected with node name, this will be base. Additional system will replace (**by default**) or extend/merge facts from json files. So in **replace mode** system should behave same as before.

@dylanratcliffe Any thoughts?