### PR TITLE
Add before and after :each blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ In the example below we have referred to `centos6a` and `centos7b` in all of our
   - **type** *statement or rvalue*
   - **returns** *Optional: A value to return*
 
-**before and after conditions** We can set before and after blocks before each spec test. Each before or after block accepts a condition. The facts of a node
-are available through the `node_facts` hash.
+**before and after conditions** We can set before and after blocks before each spec test. These are usually used when the functions to stub are conditional: stub functionx if the OS is windows, stub functiony if the fact java_installed is true. The facts are available through the `node_facts` hash.
+
 ```yaml
 before:
   - "Puppet::Util::Platform.stubs(:'windows?').returns(node_facts['kernel'] == 'windows')"

--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ In the example below we have referred to `centos6a` and `centos7b` in all of our
   - **type** *statement or rvalue*
   - **returns** *Optional: A value to return*
 
+**before and after conditions** We can set before and after blocks before each spec test. Each before or after block accepts a condition.
+```yaml
+before:
+  - "Puppet::Util::Platform.stubs(:'windows?').returns(:facts['kernel'] == 'windows')"
+
+after:
+  - "echo 'Test finished running'
+``` 
+
 **opts** The `opts` section overrides defaults for the `Onceover::Controlrepo` class' `opts` hash.
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ Why an array of hashes? Well, that is so that we can refer to the same node or n
 
 In the example below we have referred to `centos6a` and `centos7b` in all of our tests as they are in `all_nodes`, `non_windows_servers` and `centos_severs`. However we have *left the more specific references to last*. This is because entries in the test_matrix will override entries above them if applicable. Meaning that we are still only testing each class on the two Centos servers once (Because the gem does de-duplication before running the tests), but also making sure we run `roles::frontend_webserver` twice before checking for idempotency.
 
-**functions** In this section we can add functions that we want to mock when running spec tests. Each function takes the following agruments:
+**functions** In this section we can add functions that we want to mock when running spec tests. Each function takes the following arguments:
   - **type** *statement or rvalue*
   - **returns** *Optional: A value to return*
 
-**before and after conditions** We can set before and after blocks before each spec test. These are usually used when the functions to stub are conditional: stub functionx if the OS is windows, stub functiony if the fact java_installed is true. The facts are available through the `node_facts` hash.
+**before and after conditions** We can set `before` and `after` blocks before each spec test. These are usually used when the functions to stub are conditional: stub functionx if the OS is windows, stub functiony if the fact java_installed is true. The facts are available through the `node_facts` hash.
 
 ```yaml
 before:

--- a/README.md
+++ b/README.md
@@ -114,13 +114,14 @@ In the example below we have referred to `centos6a` and `centos7b` in all of our
   - **type** *statement or rvalue*
   - **returns** *Optional: A value to return*
 
-**before and after conditions** We can set before and after blocks before each spec test. Each before or after block accepts a condition.
+**before and after conditions** We can set before and after blocks before each spec test. Each before or after block accepts a condition. The facts of a node
+are available through the `node_facts` hash.
 ```yaml
 before:
-  - "Puppet::Util::Platform.stubs(:'windows?').returns(:facts['kernel'] == 'windows')"
+  - "Puppet::Util::Platform.stubs(:'windows?').returns(node_facts['kernel'] == 'windows')"
 
 after:
-  - "echo 'Test finished running'
+  - "puts 'Test finished running'"
 ``` 
 
 **opts** The `opts` section overrides defaults for the `Onceover::Controlrepo` class' `opts` hash.

--- a/lib/onceover/testconfig.rb
+++ b/lib/onceover/testconfig.rb
@@ -23,6 +23,8 @@ class Onceover
     attr_accessor :filter_classes
     attr_accessor :filter_nodes
     attr_accessor :mock_functions
+    attr_accessor :before_conditions
+    attr_accessor :after_conditions
     attr_accessor :skip_r10k
     attr_accessor :strict_variables
 
@@ -35,15 +37,17 @@ class Onceover
         raise "Could not parse #{file}, check that it is valid YAML and that the encoding is correct"
       end
 
-      @classes          = []
-      @nodes            = []
-      @node_groups      = []
-      @class_groups     = []
-      @spec_tests       = []
-      @acceptance_tests = []
-      @opts             = opts
-      @mock_functions   = config['functions']
-      @strict_variables = opts[:strict_variables] ? 'yes' : 'no'
+      @classes           = []
+      @nodes             = []
+      @node_groups       = []
+      @class_groups      = []
+      @spec_tests        = []
+      @acceptance_tests  = []
+      @opts              = opts
+      @mock_functions    = config['functions']
+      @before_conditions = config['before']
+      @after_conditions  = config['after']
+      @strict_variables  = opts[:strict_variables] ? 'yes' : 'no'
 
       # Initialise all of the classes and nodes
       config['classes'].each { |clarse| Onceover::Class.new(clarse) } unless config['classes'] == nil

--- a/templates/test_spec.rb.erb
+++ b/templates/test_spec.rb.erb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+
 <% test.classes.each do |cls| -%>
 describe "<%= cls.name %>" do
 
@@ -18,7 +19,8 @@ let!(:<%= function %>) { MockFunction.new('<%= function %>') { |f|
 <% end -%>
 <% test.nodes.each do |node| -%>
   context "using fact set <%= node.name %>" do
-    let(:facts) { <%= node.fact_set %> }
+    node_facts = <%= node.fact_set %>
+    let(:facts) { node_facts }
 <% if @before_conditions -%>
     before :each do
 <% @before_conditions.each do |function| -%>

--- a/templates/test_spec.rb.erb
+++ b/templates/test_spec.rb.erb
@@ -19,6 +19,20 @@ let!(:<%= function %>) { MockFunction.new('<%= function %>') { |f|
 <% test.nodes.each do |node| -%>
   context "using fact set <%= node.name %>" do
     let(:facts) { <%= node.fact_set %> }
+<% if @before_conditions -%>
+    before :each do
+<% @before_conditions.each do |function| -%>
+      <%= function %>
+<% end -%>
+    end
+<% end -%>
+<% if @after_conditions -%>
+    after :each do
+<% @after_conditions.each do |function| -%>
+      <%= function %>
+<% end -%>
+    end
+<% end -%>
 <% if pre_condition -%>
     let(:pre_condition) {
       pp = <%= '<<' %>-END

--- a/templates/test_spec.rb.erb
+++ b/templates/test_spec.rb.erb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 
-
 <% test.classes.each do |cls| -%>
 describe "<%= cls.name %>" do
 


### PR DESCRIPTION
If we want to stub a function globally, we can use the `function` setting in onceover.yaml. However, there are some times in which the functions to stub depend on the value of a fact. 

I ran into a rspec/puppet [issue](https://github.com/rodjek/rspec-puppet/issues/192) which shows as solved, but made my tests fail. The fix was to add a before pre-condition to each test:

```
    before :each do
      Puppet::Util::Platform.stubs(:'windows?').returns(node_facts['kernel'] == 'windows' ? true : false)
    end
```

I could not find an easy way to incorporate this into my tests without actually modifying the gem, so here is my solution. I used this [control repo](https://github.com/LMacchi/test_control_repo) to test it.

- Add before and after attribute accessors
- Expose the facts in the tests via a `node_facts` variable in the test template
- Add before and after blocks to the test template
- Revamp readme

I added only `:each` since `:all` and `:suite` don't seem to make much sense in the context of onceover.

I'm not the best coder, so if you can think of a more elegant way to do so, please feel free to refactor/disregard my code in favor of a better solution.