### PR TITLE
Add trusted facts support

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,6 @@ You can add trusted facts to the nodesets by creating a new section called trust
   "trusted": {
     "pp_role": "agent",
     "pp_datacenter": "puppet",
-    "pp_created_by": "laura"
   },
   "values": {
     "aio_agent_build": "1.10.4",

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ In the example below we have referred to `centos6a` and `centos7b` in all of our
   - **type** *statement or rvalue*
   - **returns** *Optional: A value to return*
 
-**before and after conditions** We can set `before` and `after` blocks before each spec test. These are usually used when the functions to stub are conditional: stub functionx if the OS is windows, stub functiony if the fact java_installed is true. The facts are available through the `node_facts` hash.
+**before and after conditions** We can set `before` and `after` blocks before each spec test. These are usually used when the functions to stub are conditional: stub functionx if the OS is windows, stub functiony if the fact java_installed is true. The facts are available through the `node_facts` hash and the trusted facts as `trusted_facts`.
 
 ```yaml
 before:
@@ -249,6 +249,27 @@ Once we have our factset all we need to do is copy it into `spec/factsets/` insi
 `spec/factsets/server2008r2.json`
 
 Would map to a node named `server2008r2` in `onceover.yaml`
+
+#### Trusted Facts
+
+You can add trusted facts to the nodesets by creating a new section called trusted:
+
+```
+{
+  "name": "node.puppetlabs.net",
+  "trusted": {
+    "pp_role": "agent",
+    "pp_datacenter": "puppet",
+    "pp_created_by": "laura"
+  },
+  "values": {
+    "aio_agent_build": "1.10.4",
+    "aio_agent_version": "1.10.4",
+    "architecture": "x86_64",
+
+```
+
+Notice that the `extensions` part is implied. The first fact in that example translates to `$trusted['extensions']['pp_role']` in Puppet code.
 
 ### nodesets
 

--- a/lib/onceover/controlrepo.rb
+++ b/lib/onceover/controlrepo.rb
@@ -179,7 +179,6 @@ class Onceover
       all_facts = []
       logger.debug "Reading factsets"
       @facts_files.each do |file|
-        logger.debug "########### Retrieving #{key} for #{file} ############"
         all_facts << read_facts(file)[key]
       end
       if filter

--- a/lib/onceover/controlrepo.rb
+++ b/lib/onceover/controlrepo.rb
@@ -70,7 +70,11 @@ class Onceover
     end
 
     def self.facts(filter = nil)
-      @@existing_controlrepo.facts(filter)
+      @@existing_controlrepo.facts(filter, 'values')
+    end
+
+    def self.trusted_facts(filter = nil)
+      @@existing_controlrepo.facts(filter, 'trusted')
     end
 
     def self.hiera_config_file
@@ -170,12 +174,13 @@ class Onceover
       classes.flatten
     end
 
-    def facts(filter = nil)
+    def facts(filter = nil, key = 'values')
       # Returns an array facts hashes
       all_facts = []
       logger.debug "Reading factsets"
       @facts_files.each do |file|
-        all_facts << read_facts(file)['values']
+        logger.debug "########### Retrieving #{key} for #{file} ############"
+        all_facts << read_facts(file)[key]
       end
       if filter
         # Allow us to pass a hash of facts to filter by
@@ -579,7 +584,7 @@ class Onceover
       begin
         result = JSON.parse(file)
       rescue JSON::ParserError
-        raise "Could not parse the JSON file, check that it is valid JSON and that the encoding is correct"
+        raise "Could not parse the file #{facts_file}, check that it is valid JSON and that the encoding is correct"
       end
       result
     end

--- a/lib/onceover/node.rb
+++ b/lib/onceover/node.rb
@@ -8,6 +8,7 @@ class Onceover
     attr_accessor :name
     attr_accessor :beaker_node
     attr_accessor :fact_set
+    attr_accessor :trusted_set
 
     def initialize(name)
       @name = name
@@ -19,9 +20,12 @@ class Onceover
           File.basename(facts_file, '.json') == name
         }
         @fact_set = Onceover::Controlrepo.facts[facts_file_index]
+        @trusted_set = Onceover::Controlrepo.trusted_facts[facts_file_index]
       rescue TypeError
         @fact_set = nil
+        @trusted_set = nil
       end
+
       @@all << self
 
     end

--- a/templates/test_spec.rb.erb
+++ b/templates/test_spec.rb.erb
@@ -19,7 +19,9 @@ let!(:<%= function %>) { MockFunction.new('<%= function %>') { |f|
 <% test.nodes.each do |node| -%>
   context "using fact set <%= node.name %>" do
     node_facts = <%= node.fact_set %>
+    trusted_facts = <%= node.trusted_set %>
     let(:facts) { node_facts }
+    let(:trusted_facts) { trusted_facts }
 <% if @before_conditions -%>
     before :each do
 <% @before_conditions.each do |function| -%>

--- a/templates/test_spec.rb.erb
+++ b/templates/test_spec.rb.erb
@@ -19,9 +19,11 @@ let!(:<%= function %>) { MockFunction.new('<%= function %>') { |f|
 <% test.nodes.each do |node| -%>
   context "using fact set <%= node.name %>" do
     node_facts = <%= node.fact_set %>
-    trusted_facts = <%= node.trusted_set %>
     let(:facts) { node_facts }
+<% if node.trusted_set -%>
+    trusted_facts = <%= node.trusted_set %>
     let(:trusted_facts) { trusted_facts }
+<% end -%>
 <% if @before_conditions -%>
     before :each do
 <% @before_conditions.each do |function| -%>


### PR DESCRIPTION
Add trusted facts support following [rspec docs](http://rspec-puppet.com/documentation/classes).

I pretty much replicated what you're doing with facts, in order to keep the code consistent.

I updated the docs to explain how to use them (TL;DR: add them to the factset).

I tested it with [my control repo](https://github.com/LMacchi/my-control-repo/tree/trusted), branch trusted.

Also I made so many syntax errors that I figured it would be nice to give a little more detail when a factset fails to be parsed.

This would solve issue #151 .