### PR TITLE
WIP fix config opts after 36f663 

### DIFF
--- a/lib/onceover/controlrepo.rb
+++ b/lib/onceover/controlrepo.rb
@@ -126,7 +126,7 @@ class Onceover
       $temp_modulepath  = nil
       @manifest         = opts[:manifest]         || config['manifest'] ? File.expand_path(config['manifest'], @root) : nil
       @opts             = opts
-      logger.level = :debug if @opts[:debug]
+      logger.level = :debug if @opts['debug']
       @@existing_controlrepo = self
     end
 


### PR DESCRIPTION
```
opts:
  :debug: true
```
 results in `Psych::DisallowedClass: Tried to load unspecified class: Symbol`

likely caused by https://github.com/dylanratcliffe/onceover/commit/36f663ca2789805f3df9f60ea4e25df1ae333d48#diff-5a5bc6300bd63b199d4881311c1e770c 
switiching `YAML.load()` to `YAML.safe_load()`

---

Looking at this, the same seems to be the case for all the other `opts`?

- should I add the rest into this PR and also update testconfig.rb?

- or can someone with more rubybrain change the validator? ;-)