### PR TITLE
Allow loading symbols from config file

### DIFF
--- a/lib/onceover/testconfig.rb
+++ b/lib/onceover/testconfig.rb
@@ -31,7 +31,7 @@ class Onceover
 
     def initialize(file, opts = {})
       begin
-        config = YAML.safe_load(File.read(file))
+        config = YAML.safe_load(File.read(file), [Symbol])
       rescue Errno::ENOENT
         raise "Could not find #{file}"
       rescue Psych::SyntaxError


### PR DESCRIPTION
This is completely untested, but likely to be a better fix for #164.