### PR TITLE
(GH-46) Enable tests to be run on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 *.gem
 Gemfile.lock
+Gemfile.local
 
 # Bundler / Rbenv
 /.bundle

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -691,3 +691,7 @@ Style/ZeroLengthPredicate:
 
 Bundler/OrderedGems:
   Enabled: false
+
+  # Enforce LF line endings, even when on Windows
+Layout/EndOfLine:
+  EnforcedStyle: lf

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,13 @@
 source 'https://rubygems.org'
 
 gemspec
+
+# Evaluate Gemfile.local if it exists
+if File.exists? "#{__FILE__}.local"
+  eval(File.read("#{__FILE__}.local"), binding)
+end
+
+# Evaluate ~/.gemfile if it exists
+if File.exists?(File.join(Dir.home, '.gemfile'))
+  eval(File.read(File.join(Dir.home, '.gemfile')), binding)
+end

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,12 @@ require 'rspec/core/rake_task'
 require 'cucumber/rake/task'
 Gem::Tasks.new
 
+def windows?
+  # Ruby only sets File::ALT_SEPARATOR on Windows and the Ruby standard
+  # library uses that to test what platform it's on.
+  !!File::ALT_SEPARATOR
+end
+
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.rspec_opts = '--pattern spec/onceover/**/*_spec.rb'
 end
@@ -30,7 +36,11 @@ task :syntax do
   require 'find'
   Find.find(*paths) do |path|
     next unless path =~ /\.rb$/
-    sh "ruby -cw #{path} > /dev/null"
+    if windows?
+      sh "ruby -cw #{path} > NUL"
+    else
+      sh "ruby -cw #{path} > /dev/null"
+    end
   end
 end
 


### PR DESCRIPTION
Previously rubocop would raise warnings if git cloned all files LF as rubocop
always expects files on Windows to be CRLF.  This commit changes rubocop to
always expect ruby files to have LF line endings as per non-Windows OSes.

---

reviously only gems within the gemspec could be bundled however this prevents
developers using the preferred debug tools etc.  This commit adds the ability
for the Gemfile to include per profile and per project Gemfile additions via the
common ~/.gemfile and Gemfile.local files.  This commit also adds Gemfile.local
to the ignore list, so local files wil not be checked in.

---

Previously the rakefile always assumed in was on a non-Windows OS, using
/dev/null redirection.  This commit updates the Rakefile so knows whether it is
running on a Windows platform and modify the null redirection appropriately.