### PR TITLE
Fixes moch_with deprecation

### DIFF
--- a/templates/spec_helper.rb.erb
+++ b/templates/spec_helper.rb.erb
@@ -1,3 +1,6 @@
+RSpec.configure do |c|
+  c.mock_with :rspec
+end
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-utils'
 require 'rspec_junit_formatter'


### PR DESCRIPTION
PR to fix the #174  mocha_with deprecation by setting mock_with: rspec in the spec_helper.rb
