### PR TITLE
Do not strip newline at the end of the Puppetfile

### DIFF
--- a/lib/onceover/controlrepo.rb
+++ b/lib/onceover/controlrepo.rb
@@ -297,7 +297,7 @@ class Onceover
       threads.map(&:join)
       puppetfile_string = queue.pop
 
-      File.open(@puppetfile, 'w') {|f| f.write(puppetfile_string.join("\n")) }
+      File.open(@puppetfile, 'w') {|f| f.puts(puppetfile_string.join("\n")) }
       puts "#{'changed'.yellow} #{@puppetfile}"
     end
 


### PR DESCRIPTION
The Puppetfile is a text file, so it must end with a '\n'. According to the POSIX specification:

[3.403] Text File
> A file that contains characters organized into zero or more lines.

[3.206] Line
> A sequence of zero or more non- <newline> characters plus a terminating <newline> character.

[3.403]:https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_403
[3.206]:https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206