### PR TITLE
Skip over invalid character errors parsing some puppet code

### DIFF
--- a/lib/onceover/controlrepo.rb
+++ b/lib/onceover/controlrepo.rb
@@ -640,8 +640,12 @@ class Onceover
     def find_classname(filename)
       file = File.new(filename, "r")
       while (line = file.gets)
-        if line =~ /^class (\w+(?:::\w+)*)/
-          return $1
+        begin      
+          if line =~ /^class (\w+(?:::\w+)*)/
+            return $1
+          end
+        rescue ArgumentError => e
+          logger.error "ignoring invalid line in file: #{filename} (#{e.message}) - line: '#{line}'"
         end
       end
       return nil


### PR DESCRIPTION
Fixes #207 

Where bad characters are found in puppet code users now get an error like this:

```
ERROR	 -> ignoring invalid line in file: /shared/.onceover/etc/puppetlabs/code/environments/production/modules/docker/manifests/stack.pp (invalid byte sequence in US-ASCII) - line: '#  Only accepts (“always”|“changed”|“never”)
'
ERROR	 -> ignoring invalid line in file: /shared/.onceover/etc/puppetlabs/code/environments/production/modules/docker/manifests/stack.pp (invalid byte sequence in US-ASCII) - line: '#  Only accepts (“always”|“changed”|“never”)
```