### PR TITLE
(#215) Simplfy and speed up cache building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tmp
 
 .cucumber
 .vscode
+.idea


### PR DESCRIPTION
Existing onceover cache building code is slow and this is already noted as a
`TODO` in the code.

Rewrite the internals of the `Onceover::Deploy` class:
1.  Update comments
2.  Build a list of excluded directories using whole paths so they can be
    easily filtered
3.  Build the content for `onceover_manifest.json` as we are processing the
    directory tree, so the `map` operation can be deleted
4.  Completely skip child directories of any directories we exclude (`prune`)
5.  Descend the control repo using Ruby's `Find` module instead of the
    `get_children_recursive` function (deleted)
6.  Process directories and copied files in a single pass
7.  Move the `require` for `json` to live with the other `require` lines
8.  Update the code to dump `onceover-manifest.json`. Since we already exclude
    the root directory we can just write out the whole array as-is

Rest of code left in-place