### PR TITLE
Added ability to hand `=` in environment.conf and worked around CRI issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ gemspec
 
 gem 'pry-coolline', '> 0.0', '< 1.0.0'
 
+# Cri 2.15.6 broke r10k and they can't be used together
+gem 'cri', '<= 2.15.5'
+
 if ENV['PUPPET_VERSION']
   gem 'puppet', ENV['PUPPET_VERSION']
 end

--- a/lib/onceover/controlrepo.rb
+++ b/lib/onceover/controlrepo.rb
@@ -399,7 +399,6 @@ class Onceover
     end
 
     def config
-      # Parse the file
       logger.debug "Reading #{@environment_conf}"
       env_conf = File.read(@environment_conf)
       env_conf = env_conf.split("\n")
@@ -410,7 +409,9 @@ class Onceover
       # Map the lines into a hash
       environment_config = {}
       env_conf.each do |line|
-        environment_config.merge!(Hash[*line.split('=').map { |s| s.strip}])
+        if matches = line.match(/^(\S+)\s*=(.*)$/)
+          environment_config[matches[1]] = matches[2].strip
+        end
       end
 
       # Finally, split the modulepath values and return
@@ -419,7 +420,8 @@ class Onceover
       rescue
         raise "modulepath was not found in environment.conf, don't know where to look for roles & profiles"
       end
-      return environment_config
+      
+      environment_config
     end
 
     def r10k_config_file

--- a/onceover.gemspec
+++ b/onceover.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'r10k', '>=2.1.0'
   s.add_runtime_dependency 'puppet', '>=3.4.0'
   s.add_runtime_dependency 'git'
-  s.add_runtime_dependency 'cri', '>= 2.6'
+  s.add_runtime_dependency 'cri', '>= 2.6', '<= 2.15.5'
   s.add_runtime_dependency 'colored', '~> 1.2'
   s.add_runtime_dependency 'logging', '>= 2.0.0'
   s.add_runtime_dependency 'deep_merge', '>= 1.0.0'

--- a/spec/fixtures/controlrepos/basic/environment.conf
+++ b/spec/fixtures/controlrepos/basic/environment.conf
@@ -1,2 +1,7 @@
 modulepath          = site:modules:$basemodulepath
+
+# Comments!    
+
+value_with_equals = 'foo=bar'
+
 config_version      = 'scripts/config_version.sh $environmentpath $environment'


### PR DESCRIPTION
This means that `environment.conf` entries that contain an `=` in the value will now work. Also make the CRI dependency more specific as they have broken r10k.

Once r10k takes on this dependency or fixes [Issue 936](https://github.com/puppetlabs/r10k/issues/936) we can remove this dep