### PR TITLE
Fixed escaping in pre_conditions

### DIFF
--- a/features/cache.feature
+++ b/features/cache.feature
@@ -14,6 +14,11 @@ Feature: Create and maintain a .onceover cache
     Then the cache should exist
     And the cache should contain all controlrepo files
 
+  Scenario: Runnone onnceover in the caching repo
+    Given control repo "caching"
+    When I run onceover command "run spec --classes role::webserver"
+    Then I should not see any errors
+
   Scenario: Creating a new file
     Given existing control repo "caching"
     When I create a file "example.txt"

--- a/features/run.feature
+++ b/features/run.feature
@@ -71,5 +71,5 @@ Feature: Run rspec and acceptance test suites
   # This test is a full test using my controlrepo. It should remain at the end because it takes ages
   Scenario: Run advanced spec tests
     Given control repo "puppet_controlrepo"
-    When I run onceover command "run spec"
+    When I run onceover command "run spec -p"
     Then I should not see any errors

--- a/spec/fixtures/controlrepos/caching/spec/pre_conditions/escaping.pp
+++ b/spec/fixtures/controlrepos/caching/spec/pre_conditions/escaping.pp
@@ -1,0 +1,7 @@
+# This should end up exactly the same in the test, backslashes should be
+# preserved
+$backslashes = '\2'
+
+# Cheak that things haven't been escaped
+unless $backslashes[0] == "\\" { fail() }
+unless $backslashes[1] == '2' { fail() }

--- a/templates/test_spec.rb.erb
+++ b/templates/test_spec.rb.erb
@@ -37,7 +37,7 @@ describe "<%= cls.name %>" do
     end
 <% end -%>
     let(:pre_condition) {
-      pp = <%= '<<' %>-END
+      pp = <%= '<<' %>-'END'
 $onceover_class = '<%= cls.name %>'
 $onceover_node  = '<%= node.name %>'
 


### PR DESCRIPTION
This means that backslashes will now be handles properly by Ruby.
Fixes #224