### PR TITLE
Fix compatibility with newer versions of `cri`

### DIFF
--- a/lib/onceover/testconfig.rb
+++ b/lib/onceover/testconfig.rb
@@ -52,10 +52,10 @@ class Onceover
       @strict_variables  = opts[:strict_variables] ? 'yes' : 'no'
       
       # Set dynamic defaults for format
-      if opts[:format] == [:defaults]
+      if Array(opts[:format]) == [:defaults]
         @formatters = opts[:parallel] ? ['OnceoverFormatterParallel'] : ['OnceoverFormatter']
       else
-        @formatters = opts[:format]
+        @formatters = Array(opts[:format])
       end
 
       # Initialise all of the classes and nodes


### PR DESCRIPTION
Ensure `opts[:format]` is always an Array. (In older versions of cri eg
2.15.6 it already is).

fixes #255