### PR TITLE
Support spec files selection before running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,13 @@ It's important to note that in order to reference a group using the *include/exc
 
 One or many tags that tests in this group should be tagged with. This allows you to run only certain tests using the `--tags` command line parameter. **NOTE:** Custom spec tests will always be run as they are not subject to tags
 
+**include_spec_files** *Default: [**/*]*
+
+Glob to select additionnal files to be run during `onceover` spec tests.
+
+Default is to select all files located in the repo spec directory, usually `spec/`.
+If you have some RSpec tests that depend on a different RSpec configuration than `onceover` or want, for example, to have a different job in your CI to run your own unit tests, you can use this option to select which spec files to run during `onceover` spec tests.
+
 ### factsets
 
 This gem comes with a few pre-canned factsets. These are listed under the `nodes` sections of `onceover.yaml` when you run `onceover init`. You can also add your own factsets by putting them in:

--- a/lib/onceover/runner.rb
+++ b/lib/onceover/runner.rb
@@ -24,8 +24,8 @@ class Onceover
       FileUtils.mkdir_p("#{@repo.tempdir}/spec/classes")
       FileUtils.mkdir_p("#{@repo.tempdir}/spec/acceptance/nodesets")
 
-      # Copy our entire spec directory over
-      FileUtils.cp_r("#{@repo.spec_dir}", "#{@repo.tempdir}")
+      # Copy specified spec files over
+      @config.copy_spec_files(@repo)
 
       # Create the Rakefile so that we can take advantage of the existing tasks
       @config.write_rakefile(@repo.tempdir, "spec/classes/**/*_spec.rb")

--- a/lib/onceover/testconfig.rb
+++ b/lib/onceover/testconfig.rb
@@ -50,6 +50,7 @@ class Onceover
       @before_conditions = config['before'] || []
       @after_conditions  = config['after']
       @strict_variables  = opts[:strict_variables] ? 'yes' : 'no'
+      @included_specs    = [config['include_spec_files'] || ['**/*']].flatten
       
       # Set dynamic defaults for format
       if Array(opts[:format]) == [:defaults]
@@ -234,6 +235,19 @@ class Onceover
         "#{location}/spec_helper.rb",
         Onceover::Controlrepo.evaluate_template('spec_helper.rb.erb', binding)
       )
+    end
+
+    def copy_spec_files(repo)
+      source_files = @included_specs.map { |glob| Dir.glob "#{repo.spec_dir}/#{glob}" }.flatten.uniq
+      source_files.each do |source_file|
+        target_file = File.join(repo.tempdir, 'spec', source_file.delete_prefix(repo.spec_dir))
+        if File.directory?(source_file)
+          FileUtils.cp_r source_file, target_file unless File.exists? target_file
+        else
+          FileUtils.mkdir_p File.dirname target_file
+          FileUtils.cp source_file, target_file
+        end
+      end
     end
 
     def create_fixtures_symlinks(repo)

--- a/lib/onceover/testconfig.rb
+++ b/lib/onceover/testconfig.rb
@@ -240,7 +240,7 @@ class Onceover
     def copy_spec_files(repo)
       source_files = @included_specs.map { |glob| Dir.glob "#{repo.spec_dir}/#{glob}" }.flatten.uniq
       source_files.each do |source_file|
-        target_file = File.join(repo.tempdir, 'spec', source_file.delete_prefix(repo.spec_dir))
+        target_file = File.join(repo.tempdir, 'spec', source_file.sub(/^#{repo.spec_dir}/, ''))
         if File.directory?(source_file)
           FileUtils.cp_r source_file, target_file unless File.exists? target_file
         else


### PR DESCRIPTION
This PR is related to #261 

Before this PR, using `onceover` when you have other _traditional_ `rspec` spec tests may be a problem if you:
 - want/need a different `rspec` setup; or
 - want to have a different job in CI for `onceover` spec tests and _traditional_ `rspec` tests

This PR provides a way to only include selected files from `spec/` directory, before running `onceover`.