### PR TITLE
Improve show puppetfile

### DIFF
--- a/lib/onceover/controlrepo.rb
+++ b/lib/onceover/controlrepo.rb
@@ -256,6 +256,8 @@ class Onceover
 
       threads.map(&:join)
 
+      output_array.sort_by! { |line| line[0] }
+
       puts Terminal::Table.new(headings: ["Full Name", "Current Version", "Latest Version", "Out of Date?", "Endorsement", "Superseded by"], rows: output_array)
     end
 

--- a/lib/onceover/controlrepo.rb
+++ b/lib/onceover/controlrepo.rb
@@ -206,7 +206,7 @@ class Onceover
     end
 
     def print_puppetfile_table
-      require 'table_print'
+      require 'terminal-table'
       require 'versionomy'
       require 'colored'
       require 'r10k/puppetfile'
@@ -221,48 +221,42 @@ class Onceover
       threads      = []
       puppetfile.modules.each do |mod|
         threads << Thread.new do
-          return_hash = {}
+          row = []
           logger.debug "Loading data for #{mod.full_name}"
-          return_hash[:full_name] = mod.full_name
+          row << mod.full_name
           if mod.is_a?(R10K::Module::Forge)
-            return_hash[:current_version] = mod.expected_version
-            return_hash[:latest_version] = mod.v3_module.current_release.version
-            return_hash[:endorsement] = mod.v3_module.endorsement
+            row << mod.expected_version
+            row << mod.v3_module.current_release.version
+
+            current = Versionomy.parse(mod.expected_version)
+            latest = Versionomy.parse(mod.v3_module.current_release.version)
+            row << if current.major < latest.major
+                     "Major".red
+                   elsif current.minor < latest.minor
+                     "Minor".yellow
+                   elsif current.tiny < latest.tiny
+                     "Tiny".green
+                   else
+                     "No".green
+                   end
+
+            row << mod.v3_module.endorsement
             superseded_by = mod.v3_module.superseded_by
-            return_hash[:superseded_by] = superseded_by.nil? ? '' : superseded_by[:slug]
-            current = Versionomy.parse(return_hash[:current_version])
-            latest = Versionomy.parse(return_hash[:latest_version])
-            if current.major < latest.major
-              return_hash[:out_of_date] = "Major".red
-            elsif current.minor < latest.minor
-              return_hash[:out_of_date] = "Minor".yellow
-            elsif current.tiny < latest.tiny
-              return_hash[:out_of_date] = "Tiny".green
-            else
-              return_hash[:out_of_date] = "No".green
-            end
+            row << (superseded_by.nil? ? '' : superseded_by[:slug])
           else
-            return_hash[:current_version] = "N/A"
-            return_hash[:latest_version]  = "N/A"
-            return_hash[:out_of_date]     = "N/A"
-            return_hash[:endorsement]     = "N/A"
-            return_hash[:superseded_by]   = "N/A"
+            row << "N/A"
+            row << "N/A"
+            row << "N/A"
+            row << "N/A"
+            row << "N/A"
           end
-          output_array << return_hash
+          output_array << row
         end
       end
 
       threads.map(&:join)
 
-      tp(
-        output_array,
-        {:full_name       => {:display_name => "Full Name"}},
-        {:current_version => {:display_name => "Current Version"}},
-        {:latest_version  => {:display_name => "Latest Version"}},
-        {:out_of_date     => {:display_name => "Out of Date?"}},
-        {:endorsement     => {:display_name => "Endorsement"}},
-        {:superseded_by   => {:display_name => "Superseded by"}}
-      )
+      puts Terminal::Table.new(headings: ["Full Name", "Current Version", "Latest Version", "Out of Date?", "Endorsement", "Superseded by"], rows: output_array)
     end
 
     def update_puppetfile

--- a/onceover.gemspec
+++ b/onceover.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rspec', '>= 3.0.0'
   s.add_runtime_dependency 'rspec-puppet', ">= 2.4.0"
   s.add_runtime_dependency 'rspec_junit_formatter', '>= 0.2.0'
-  s.add_runtime_dependency 'table_print', '>= 1.0.0'
+  s.add_runtime_dependency 'terminal-table', '>= 1.8.0'
   s.add_runtime_dependency 'versionomy', '>= 0.5.0'
 
 end


### PR DESCRIPTION
Improve the output of `onceover show puppetfile`:

* Correctly align columns of text with ANSI escape sequences thanks to [terminal-tables](https://rubygems.org/gems/terminal-table/versions/1.8.0);
* Sort lines by module full name.


Before:
![before](https://user-images.githubusercontent.com/148721/86866632-0a992b80-c06d-11ea-8838-cdd4de3a5ced.png)

After:
![after](https://user-images.githubusercontent.com/148721/86866551-e2a9c800-c06c-11ea-9593-6a6cab4c8f33.png)
