### PR TITLE
Add choco_install_path fact to Windows factsets.

### DIFF
--- a/factsets/Windows_Server-2008r2-64.json
+++ b/factsets/Windows_Server-2008r2-64.json
@@ -162,6 +162,7 @@
     "staging_http_get": "powershell",
     "staging_windir": "C:\\ProgramData\\staging",
     "system32": "C:\\Windows\\system32",
+    "choco_install_path": "C:\\ProgramData\\chocolatey",
     "system_uptime": {
       "days": 0,
       "hours": 0,

--- a/factsets/Windows_Server-2012r2-64.json
+++ b/factsets/Windows_Server-2012r2-64.json
@@ -143,6 +143,7 @@
     "rubyversion": "2.1.7",
     "serialnumber": "0",
     "system32": "C:\\Windows\\system32",
+    "choco_install_path": "C:\\ProgramData\\chocolatey",
     "system_uptime": {
       "days": 0,
       "hours": 0,

--- a/factsets/windows-10-64.json
+++ b/factsets/windows-10-64.json
@@ -83,6 +83,7 @@
     "rubysitedir": "C:/tools/ruby24/lib/ruby/site_ruby/2.4.0",
     "rubyversion": "2.4.3",
     "system32": "C:\\Windows\\system32",
+    "choco_install_path": "C:\\ProgramData\\chocolatey",
     "system_uptime": {
       "seconds": 1113359,
       "hours": 309,


### PR DESCRIPTION
Seeing the following errors when running Onceover on Windows roles that include the puppetlabs/chocolatey module.

```
role::windows_webservice: failed
  errors:
    Evaluation Error: Error while evaluating a Function Call, Class[Chocolatey]: parameter 'choco_install_location' expects a match for Stdlib::Windowspath = Pattern[/^(([a-zA-Z]:[\\\/])|([\\\/][\\\/][^\\\/]+[\\\/][^\\\/]+)|([\\\/][\\\/]\?[\\\/][^\\\/]+))/], got Undef
      file: site-modules/profile/manifests/baseline/windows.pp
      line: 11
      column: 3
      factsets: windev
```
Because facter fact choco_install_location doesn't exist. On a real Puppet run the fact would be created via a ruby function deployed by plugin-sync. 
Added
```
 "choco_install_path": "C:\\ProgramData\\chocolatey", 
```
to the 3 Windows factsets. 