### PR TITLE
Improve RSpec tags support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,17 @@ Hopefully this config file will be fairly self explanatory once you see it, but 
       - {nodes_to_test}: # The name of a node or node group
           classes: '{classes_to_test}' # the name of a class or
           tests: '{all_tests|acceptance|spec}' # acceptance deprecated/broken, set to spec
-          {valid_option}: {value} # Check the doco for available options
+          {valid_option}: {value} # See below
     ```
+
+    Valid options:
+
+    - `tags`
+
+        Default: `nil`
+
+       One or many tags that tests in this group should be tagged with.
+       This allows you to run only certain tests using the `--tags` command line parameter.
 
 #### Advanced settings
 
@@ -172,15 +181,6 @@ Hopefully this config file will be fairly self explanatory once you see it, but 
     after:
       - "puts 'Test finished running'"
     ```
-
-- `tags`
-
-    Default: `nil`
-
-    One or many tags that tests in this group should be tagged with.
-    This allows you to run only certain tests using the `--tags` command line parameter.
-
-    **NOTE**: Custom spec tests will always be run as they are not subject to tags
 
 - `include_spec_files`
 

--- a/features/zzz_run.feature
+++ b/features/zzz_run.feature
@@ -1,6 +1,6 @@
 @run
 Feature: Run rspec and acceptance test suites
-  Onceover should allow to run rspec and acceptance test for all profvile and role classes
+  Onceover should allow to run rspec and acceptance test for all profile and role classes
   or for any part of them. Use should set if he wants to see only summary of tests or full
   log info.
 

--- a/lib/onceover/runner.rb
+++ b/lib/onceover/runner.rb
@@ -37,8 +37,6 @@ class Onceover
       # Create spec_helper_accpetance.rb
       @config.write_spec_helper_acceptance("#{@repo.tempdir}/spec", @repo)
 
-      # TODO: Remove all tests that do not match set tags
-
       if @mode.include?(:spec)
         # Verify all of the spec tests
         @config.spec_tests.each { |test| @config.verify_spec_test(@repo, test) }
@@ -84,8 +82,10 @@ class Onceover
           ENV['RUBYOPT']   = ENV['RUBYOPT'].to_s + ' -W0'
         end
 
-        #`bundle install --binstubs`
-        #`bin/rake spec_standalone`
+        # NOTE: This is the way to provide options to rspec according to:
+        # https://github.com/puppetlabs/puppetlabs_spec_helper/blob/master/lib/puppetlabs_spec_helper/rake_tasks.rb#L51
+        ENV['CI_SPEC_OPTIONS'] = ENV['CI_SPEC_OPTIONS'].to_s + @config.filter_tags.map { |tag| " --tag #{tag}" }.join unless @config.filter_tags.nil?
+
         if @config.opts[:parallel]
           logger.debug "Running #{@command_prefix}rake parallel_spec from #{@repo.tempdir}"
           result = run_command(@command_prefix.strip.split, 'rake', 'parallel_spec')

--- a/lib/onceover/test.rb
+++ b/lib/onceover/test.rb
@@ -25,10 +25,11 @@ class Onceover
       @classes = []
       @test_config = test_config
       @test_config.delete('classes') # remove classes from the config
-      @tags = @test_config['tags']
 
       # Make sure that tags are an array
-      @test_config['tags'] = [@test_config['tags']].flatten if @test_config['tags']
+      @test_config['tags'] ||= []
+      @test_config['tags'] = [@test_config['tags']].flatten
+      @tags = @test_config['tags']
 
       # Get the nodes we are working on
       if Onceover::Group.find(on_this)

--- a/lib/onceover/testconfig.rb
+++ b/lib/onceover/testconfig.rb
@@ -289,16 +289,25 @@ class Onceover
           # Remove tests that do not have matching tags
           tests.keep_if do |test|
             filter_list.any? do |filter|
-              if test.send(method)
-                test.send(method).include?(filter)
-              else
-                false
-              end
+              filter_test test, method, filter
             end
           end
         end
       end
       tests
+    end
+
+    def filter_test(test, method, filter)
+      if test.send(method)
+        if method == 'tags' && filter.start_with?('~')
+          filter = filter.sub(/^~/, '')
+          ! test.send(method).include?(filter)
+        else
+          test.send(method).include?(filter)
+        end
+      else
+        false
+      end
     end
   end
 end

--- a/templates/test_spec.rb.erb
+++ b/templates/test_spec.rb.erb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 <% test.classes.each do |cls| -%>
-describe "<%= cls.name %>" do
+describe "<%= cls.name %>"<%= test.tags.map { |tag| ",#{tag}: true "}.join %> do
 
 <% test.nodes.each do |node| -%>
   context "using fact set <%= node.name %>" do


### PR DESCRIPTION
On top of #275 , this PR improves the way to handle tags.

When this PR will be applied, you may
 * include/exclude custom spec from a run using RSpec tag syntax
 * exclude specific tag from a run
 * use RSpec-like syntax to include/exclude tags (e.g. `--tags ~wip` will exclude `wip` tagged specs)
