### PR TITLE
Add missing `require 'io/console'`

### DIFF
--- a/lib/onceover/runner.rb
+++ b/lib/onceover/runner.rb
@@ -1,4 +1,5 @@
 require 'backticks'
+require 'io/console'
 
 class Onceover
   class Runner


### PR DESCRIPTION
Without this I get the following error when using `--parallel`.
```
NoMethodError: undefined method `cooked!' for #<IO:<STDERR>>>
```

From https://ruby-doc.org/stdlib-2.5.0/libdoc/io/console/rdoc/IO.html#method-i-cooked
> You must require ‘io/console’ to use this method.