### PR TITLE
Fix and document :manifest opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Hopefully this config file will be fairly self explanatory once you see it, but 
       :profile_regex: '^(profile|site)::'    # Profiles include a legacy module named `site::`
       :facts_files:                          # Factset filenames use the extension`.facts` instead of `.json`
         - 'spec/factsets/*.facts'
+      :manifest: 'manifests/site.pp'         # Manifest to use while compiling (nil by default)
     ```
 
 #### Include/Exclude syntax
@@ -254,7 +255,7 @@ classes:
   - 'roles::load_balancer'
   - 'roles::syd_f5_load_balancer'
   - 'roles::windows_server'
-  - '/^role/'
+  - '/^role/'                     # Note that this regex format requires `/`
 
 nodes:
   - centos6a
@@ -308,6 +309,7 @@ functions:
 opts:
   :facts_dirs:
     - spec/factsets
+  :profile_regex: '^(profile|site)::'   # Note that this regex _doesn't_ use `/`
 ```
 
 ### Factsets

--- a/lib/onceover/controlrepo.rb
+++ b/lib/onceover/controlrepo.rb
@@ -123,8 +123,8 @@ class Onceover
       @profile_regex    = opts[:profile_regex]    ?  Regexp.new(opts[:profile_regex]) : /profile[s]?:{2}/
       @tempdir          = opts[:tempdir]          || File.expand_path('./.onceover', @root)
       $temp_modulepath  = nil
-      manifest          = opts[:manifest]         || config['manifest']
-      @manifest         = manifest ? File.expand_path(manifest, @root) : nil
+      manifest          = opts[:manifest]         || config['manifest'] || 'manifests'
+      @manifest         = File.expand_path(manifest, @root)
       @opts             = opts
       logger.level = :debug if @opts[:debug]
       @@existing_controlrepo = self

--- a/lib/onceover/controlrepo.rb
+++ b/lib/onceover/controlrepo.rb
@@ -123,7 +123,8 @@ class Onceover
       @profile_regex    = opts[:profile_regex]    ?  Regexp.new(opts[:profile_regex]) : /profile[s]?:{2}/
       @tempdir          = opts[:tempdir]          || File.expand_path('./.onceover', @root)
       $temp_modulepath  = nil
-      @manifest         = opts[:manifest]         || config['manifest'] ? File.expand_path(config['manifest'], @root) : nil
+      manifest          = opts[:manifest]         || config['manifest']
+      @manifest         = manifest ? File.expand_path(manifest) : nil
       @opts             = opts
       logger.level = :debug if @opts[:debug]
       @@existing_controlrepo = self
@@ -420,7 +421,7 @@ class Onceover
       rescue StandardError
         raise "modulepath was not found in environment.conf, don't know where to look for roles & profiles"
       end
-      
+
       environment_config
     end
 
@@ -444,7 +445,7 @@ class Onceover
     end
 
     def temp_manifest
-      config['manifest'] ? File.expand_path(config['manifest'], @tempdir) : nil
+      @manifest
     end
 
     def self.init(repo)
@@ -642,7 +643,7 @@ class Onceover
     def find_classname(filename)
       file = File.new(filename, "r")
       while (line = file.gets)
-        begin      
+        begin
           if line =~ /^class (\w+(?:::\w+)*)/
             return $1
           end

--- a/lib/onceover/controlrepo.rb
+++ b/lib/onceover/controlrepo.rb
@@ -124,7 +124,7 @@ class Onceover
       @tempdir          = opts[:tempdir]          || File.expand_path('./.onceover', @root)
       $temp_modulepath  = nil
       manifest          = opts[:manifest]         || config['manifest']
-      @manifest         = manifest ? File.expand_path(manifest) : nil
+      @manifest         = manifest ? File.expand_path(manifest, @root) : nil
       @opts             = opts
       logger.level = :debug if @opts[:debug]
       @@existing_controlrepo = self


### PR DESCRIPTION
Before this patch, running `onceover run spec` with `--manifest PATH` or
when `opts[:manifest]` is set in the `spec/onceover.yaml` file would
result in the Error `#<TypeError: no implicit conversion of nil into
String>`.

This patch fixes that issue by correcting the initialization logic for
configuring the manifests directory, and ensuring the path is used as
the value for `c.manifest` setting in `.onceover/spec/spec_helper.rb`.