### PR TITLE
Add factsets for recent CentOS, Debian, & Ubuntu

### DIFF
--- a/factsets/CentOS-8.3.2011-64.json
+++ b/factsets/CentOS-8.3.2011-64.json
@@ -1,0 +1,485 @@
+{
+  "name": "localhost.localdomain",
+  "values": {
+    "aio_agent_version": "6.19.1",
+    "architecture": "x86_64",
+    "augeas": {
+      "version": "1.12.0"
+    },
+    "augeasversion": "1.12.0",
+    "bios_release_date": "04/01/2014",
+    "bios_vendor": "SeaBIOS",
+    "bios_version": "1.13.0-1ubuntu1",
+    "blockdevice_vda_size": 11811160064,
+    "blockdevice_vda_vendor": "0x1af4",
+    "blockdevices": "vda",
+    "chassistype": "Other",
+    "disks": {
+      "vda": {
+        "size": "11.00 GiB",
+        "size_bytes": 11811160064,
+        "vendor": "0x1af4"
+      }
+    },
+    "dmi": {
+      "bios": {
+        "release_date": "04/01/2014",
+        "vendor": "SeaBIOS",
+        "version": "1.13.0-1ubuntu1"
+      },
+      "chassis": {
+        "type": "Other"
+      },
+      "manufacturer": "QEMU",
+      "product": {
+        "name": "Standard PC (i440FX + PIIX, 1996)"
+      }
+    },
+    "domain": "localdomain",
+    "facterversion": "3.14.14",
+    "filesystems": "xfs",
+    "fips_enabled": false,
+    "fqdn": "localhost.localdomain",
+    "gid": "vagrant",
+    "hardwareisa": "x86_64",
+    "hardwaremodel": "x86_64",
+    "hostname": "localhost",
+    "hypervisors": {
+      "kvm": {
+      }
+    },
+    "id": "vagrant",
+    "identity": {
+      "gid": 1000,
+      "group": "vagrant",
+      "privileged": false,
+      "uid": 1000,
+      "user": "vagrant"
+    },
+    "interfaces": "eth0,lo",
+    "ipaddress": "192.168.121.201",
+    "ipaddress6": "fe80::5054:ff:fe4c:b937",
+    "ipaddress6_eth0": "fe80::5054:ff:fe4c:b937",
+    "ipaddress6_lo": "::1",
+    "ipaddress_eth0": "192.168.121.201",
+    "ipaddress_lo": "127.0.0.1",
+    "is_virtual": true,
+    "kernel": "Linux",
+    "kernelmajversion": "4.18",
+    "kernelrelease": "4.18.0-240.1.1.el8_3.x86_64",
+    "kernelversion": "4.18.0",
+    "load_averages": {
+      "15m": 0.07,
+      "1m": 0.59,
+      "5m": 0.19
+    },
+    "macaddress": "52:54:00:4c:b9:37",
+    "macaddress_eth0": "52:54:00:4c:b9:37",
+    "manufacturer": "QEMU",
+    "memory": {
+      "swap": {
+        "available": "1.98 GiB",
+        "available_bytes": 2127929344,
+        "capacity": "0.91%",
+        "total": "2.00 GiB",
+        "total_bytes": 2147479552,
+        "used": "18.64 MiB",
+        "used_bytes": 19550208
+      },
+      "system": {
+        "available": "235.07 MiB",
+        "available_bytes": 246493184,
+        "capacity": "49.45%",
+        "total": "465.05 MiB",
+        "total_bytes": 487636992,
+        "used": "229.97 MiB",
+        "used_bytes": 241143808
+      }
+    },
+    "memoryfree": "235.07 MiB",
+    "memoryfree_mb": 235.07421875,
+    "memorysize": "465.05 MiB",
+    "memorysize_mb": 465.046875,
+    "mountpoints": {
+      "/": {
+        "available": "6.47 GiB",
+        "available_bytes": 6952439808,
+        "capacity": "35.18%",
+        "device": "/dev/vda1",
+        "filesystem": "xfs",
+        "options": [
+          "rw",
+          "seclabel",
+          "relatime",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "size": "9.99 GiB",
+        "size_bytes": 10725883904,
+        "used": "3.51 GiB",
+        "used_bytes": 3773444096
+      },
+      "/dev": {
+        "available": "214.51 MiB",
+        "available_bytes": 224927744,
+        "capacity": "0%",
+        "device": "devtmpfs",
+        "filesystem": "devtmpfs",
+        "options": [
+          "rw",
+          "seclabel",
+          "nosuid",
+          "size=219656k",
+          "nr_inodes=54914",
+          "mode=755"
+        ],
+        "size": "214.51 MiB",
+        "size_bytes": 224927744,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/hugepages": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "hugetlbfs",
+        "filesystem": "hugetlbfs",
+        "options": [
+          "rw",
+          "seclabel",
+          "relatime",
+          "pagesize=2M"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/mqueue": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "mqueue",
+        "filesystem": "mqueue",
+        "options": [
+          "rw",
+          "seclabel",
+          "relatime"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/pts": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "devpts",
+        "filesystem": "devpts",
+        "options": [
+          "rw",
+          "seclabel",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/shm": {
+        "available": "232.52 MiB",
+        "available_bytes": 243818496,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "seclabel",
+          "nosuid",
+          "nodev"
+        ],
+        "size": "232.52 MiB",
+        "size_bytes": 243818496,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/run": {
+        "available": "229.23 MiB",
+        "available_bytes": 240369664,
+        "capacity": "1.41%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "seclabel",
+          "nosuid",
+          "nodev",
+          "mode=755"
+        ],
+        "size": "232.52 MiB",
+        "size_bytes": 243818496,
+        "used": "3.29 MiB",
+        "used_bytes": 3448832
+      },
+      "/run/user/1000": {
+        "available": "46.50 MiB",
+        "available_bytes": 48762880,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "seclabel",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "size=47620k",
+          "mode=700",
+          "uid=1000",
+          "gid=1000"
+        ],
+        "size": "46.50 MiB",
+        "size_bytes": 48762880,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/sys/fs/cgroup": {
+        "available": "232.52 MiB",
+        "available_bytes": 243818496,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "ro",
+          "seclabel",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "mode=755"
+        ],
+        "size": "232.52 MiB",
+        "size_bytes": 243818496,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/var/lib/nfs/rpc_pipefs": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "sunrpc",
+        "filesystem": "rpc_pipefs",
+        "options": [
+          "rw",
+          "relatime"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      }
+    },
+    "mtu_eth0": 1500,
+    "mtu_lo": 65536,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "netmask6_eth0": "ffff:ffff:ffff:ffff::",
+    "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+    "netmask_eth0": "255.255.255.0",
+    "netmask_lo": "255.0.0.0",
+    "network": "192.168.121.0",
+    "network6": "fe80::",
+    "network6_eth0": "fe80::",
+    "network6_lo": "::1",
+    "network_eth0": "192.168.121.0",
+    "network_lo": "127.0.0.0",
+    "networking": {
+      "domain": "localdomain",
+      "fqdn": "localhost.localdomain",
+      "hostname": "localhost",
+      "interfaces": {
+        "eth0": {
+          "bindings": [
+            {
+              "address": "192.168.121.201",
+              "netmask": "255.255.255.0",
+              "network": "192.168.121.0"
+            }
+          ],
+          "bindings6": [
+            {
+              "address": "fe80::5054:ff:fe4c:b937",
+              "netmask": "ffff:ffff:ffff:ffff::",
+              "network": "fe80::"
+            }
+          ],
+          "ip": "192.168.121.201",
+          "ip6": "fe80::5054:ff:fe4c:b937",
+          "mac": "52:54:00:4c:b9:37",
+          "mtu": 1500,
+          "netmask": "255.255.255.0",
+          "netmask6": "ffff:ffff:ffff:ffff::",
+          "network": "192.168.121.0",
+          "network6": "fe80::",
+          "scope6": "link"
+        },
+        "lo": {
+          "bindings": [
+            {
+              "address": "127.0.0.1",
+              "netmask": "255.0.0.0",
+              "network": "127.0.0.0"
+            }
+          ],
+          "bindings6": [
+            {
+              "address": "::1",
+              "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+              "network": "::1"
+            }
+          ],
+          "ip": "127.0.0.1",
+          "ip6": "::1",
+          "mtu": 65536,
+          "netmask": "255.0.0.0",
+          "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+          "network": "127.0.0.0",
+          "network6": "::1",
+          "scope6": "host"
+        }
+      },
+      "ip": "192.168.121.201",
+      "ip6": "fe80::5054:ff:fe4c:b937",
+      "mac": "52:54:00:4c:b9:37",
+      "mtu": 1500,
+      "netmask": "255.255.255.0",
+      "netmask6": "ffff:ffff:ffff:ffff::",
+      "network": "192.168.121.0",
+      "network6": "fe80::",
+      "primary": "eth0",
+      "scope6": "link"
+    },
+    "operatingsystem": "CentOS",
+    "operatingsystemmajrelease": "8",
+    "operatingsystemrelease": "8.3.2011",
+    "os": {
+      "architecture": "x86_64",
+      "family": "RedHat",
+      "hardware": "x86_64",
+      "name": "CentOS",
+      "release": {
+        "full": "8.3.2011",
+        "major": "8",
+        "minor": "3"
+      },
+      "selinux": {
+        "config_mode": "enforcing",
+        "config_policy": "targeted",
+        "current_mode": "enforcing",
+        "enabled": true,
+        "enforced": true,
+        "policy_version": "32"
+      }
+    },
+    "osfamily": "RedHat",
+    "partitions": {
+      "/dev/vda1": {
+        "mount": "/",
+        "size": "10.00 GiB",
+        "size_bytes": 10736369664
+      }
+    },
+    "path": "/home/vagrant/.local/bin:/home/vagrant/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/opt/puppetlabs/bin:/sbin",
+    "physicalprocessorcount": 1,
+    "processor0": "AMD EPYC-Rome Processor",
+    "processorcount": 1,
+    "processors": {
+      "count": 1,
+      "isa": "x86_64",
+      "models": [
+        "AMD EPYC-Rome Processor"
+      ],
+      "physicalcount": 1
+    },
+    "productname": "Standard PC (i440FX + PIIX, 1996)",
+    "puppetversion": "6.19.1",
+    "ruby": {
+      "platform": "x86_64-linux",
+      "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
+      "version": "2.5.8"
+    },
+    "rubyplatform": "x86_64-linux",
+    "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
+    "rubyversion": "2.5.8",
+    "scope6": "link",
+    "scope6_eth0": "link",
+    "scope6_lo": "host",
+    "selinux": true,
+    "selinux_config_mode": "enforcing",
+    "selinux_config_policy": "targeted",
+    "selinux_current_mode": "enforcing",
+    "selinux_enforced": true,
+    "selinux_policyversion": "32",
+    "ssh": {
+      "ecdsa": {
+        "fingerprints": {
+          "sha1": "SSHFP 3 1 76c09c767a65eb99b88642f5dfc09fc1e89a80de",
+          "sha256": "SSHFP 3 2 909590096267e2ee95cb93a77b853e4658f100dd03338c6d94e29a53e19d446c"
+        },
+        "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEm5drTu++f7N7lKL2qFz6cPlYITr5eAl3CI96QptQL4vhqIEabCEVgBOWD9vJJ9hOHZdcDUiBIuHPWshtRPBYk=",
+        "type": "ecdsa-sha2-nistp256"
+      },
+      "ed25519": {
+        "fingerprints": {
+          "sha1": "SSHFP 4 1 7b24eb57aa809bb63ab1d5ed2cd5d640d9af81c0",
+          "sha256": "SSHFP 4 2 c08da73821119203a94eeae15c60f40bc1f7fe928b6b53cc1e4d886cd4485e58"
+        },
+        "key": "AAAAC3NzaC1lZDI1NTE5AAAAIHFdrdHK1OAwru/pkI09iy4FxjJytQHaek/akLO2hubo",
+        "type": "ssh-ed25519"
+      },
+      "rsa": {
+        "fingerprints": {
+          "sha1": "SSHFP 1 1 5557b29bf9291c6df01b0a3c3165fcfd8d38f808",
+          "sha256": "SSHFP 1 2 00ada027e652c06008becdd7650ac8e9020d87c2c8fcc683a07d8dfc138540dc"
+        },
+        "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDpHVc9L5224jB3cRuXU/Hn3Q5EPudHJ0b8c44pK9WGbTExjYv2szCng8G8O+O/usuIM88PLtvT5FOYFrTxspqEvruEZCbx0HIkpRnEWfnio2Wz1Z8JuMHFLNHE2E7ocEKUGCV0bu34XLjDfzJd37gkmfOtVNwpl46dgimhfBXNTDtiAkH7mWKY87ozkdJkoo/pmjPJKgCfH3nTDV2BvTJL5umeOJx8PGI1sWhh95LviMFo9meriErb98z2WYGszXiR9+Zu4sqCExAeEWHV9A/+Me63sdkhttf8cD8OHyfLAxqxGvL07ahQ89Tuap9sYYlNsOs4QARqyvmTYz9YeXBbyCJXfaY17JOOBo+InY1xCWaGQlK3/eeInznoS41fa51poimOtpF1G+pHC2YtHSfa1pCaPLXz/Ymt3YnNgAFyhgbjZEG76bF9avEgUlyX11/DL/JCXewBIGJTcKCuZHNuGUOaiNfXuTcpXrkvgMH1mEv4g00tH96JDhlyfTifOic=",
+        "type": "ssh-rsa"
+      }
+    },
+    "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEm5drTu++f7N7lKL2qFz6cPlYITr5eAl3CI96QptQL4vhqIEabCEVgBOWD9vJJ9hOHZdcDUiBIuHPWshtRPBYk=",
+    "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIHFdrdHK1OAwru/pkI09iy4FxjJytQHaek/akLO2hubo",
+    "sshfp_ecdsa": "SSHFP 3 1 76c09c767a65eb99b88642f5dfc09fc1e89a80de\nSSHFP 3 2 909590096267e2ee95cb93a77b853e4658f100dd03338c6d94e29a53e19d446c",
+    "sshfp_ed25519": "SSHFP 4 1 7b24eb57aa809bb63ab1d5ed2cd5d640d9af81c0\nSSHFP 4 2 c08da73821119203a94eeae15c60f40bc1f7fe928b6b53cc1e4d886cd4485e58",
+    "sshfp_rsa": "SSHFP 1 1 5557b29bf9291c6df01b0a3c3165fcfd8d38f808\nSSHFP 1 2 00ada027e652c06008becdd7650ac8e9020d87c2c8fcc683a07d8dfc138540dc",
+    "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDpHVc9L5224jB3cRuXU/Hn3Q5EPudHJ0b8c44pK9WGbTExjYv2szCng8G8O+O/usuIM88PLtvT5FOYFrTxspqEvruEZCbx0HIkpRnEWfnio2Wz1Z8JuMHFLNHE2E7ocEKUGCV0bu34XLjDfzJd37gkmfOtVNwpl46dgimhfBXNTDtiAkH7mWKY87ozkdJkoo/pmjPJKgCfH3nTDV2BvTJL5umeOJx8PGI1sWhh95LviMFo9meriErb98z2WYGszXiR9+Zu4sqCExAeEWHV9A/+Me63sdkhttf8cD8OHyfLAxqxGvL07ahQ89Tuap9sYYlNsOs4QARqyvmTYz9YeXBbyCJXfaY17JOOBo+InY1xCWaGQlK3/eeInznoS41fa51poimOtpF1G+pHC2YtHSfa1pCaPLXz/Ymt3YnNgAFyhgbjZEG76bF9avEgUlyX11/DL/JCXewBIGJTcKCuZHNuGUOaiNfXuTcpXrkvgMH1mEv4g00tH96JDhlyfTifOic=",
+    "swapfree": "1.98 GiB",
+    "swapfree_mb": 2029.3515625,
+    "swapsize": "2.00 GiB",
+    "swapsize_mb": 2047.99609375,
+    "system_uptime": {
+      "days": 0,
+      "hours": 0,
+      "seconds": 52,
+      "uptime": "0:00 hours"
+    },
+    "timezone": "UTC",
+    "uptime": "0:00 hours",
+    "uptime_days": 0,
+    "uptime_hours": 0,
+    "uptime_seconds": 52,
+    "virtual": "kvm",
+    "clientcert": "localhost.localdomain",
+    "clientversion": "6.19.1",
+    "clientnoop": false
+  },
+  "timestamp": "2021-01-01T01:51:42.579769660+00:00",
+  "expiration": "2021-01-01T02:21:42.580035430+00:00"
+}

--- a/factsets/Debian-10.4-64.json
+++ b/factsets/Debian-10.4-64.json
@@ -1,0 +1,476 @@
+{
+  "name": "buster",
+  "values": {
+    "aio_agent_version": "6.19.1",
+    "architecture": "amd64",
+    "augeas": {
+      "version": "1.12.0"
+    },
+    "augeasversion": "1.12.0",
+    "bios_release_date": "04/01/2014",
+    "bios_vendor": "SeaBIOS",
+    "bios_version": "1.13.0-1ubuntu1",
+    "blockdevice_vda_size": 21474836480,
+    "blockdevice_vda_vendor": "0x1af4",
+    "blockdevices": "vda",
+    "chassistype": "Other",
+    "dhcp_servers": {
+      "ens5": "192.168.121.1",
+      "system": "192.168.121.1"
+    },
+    "disks": {
+      "vda": {
+        "size": "20.00 GiB",
+        "size_bytes": 21474836480,
+        "vendor": "0x1af4"
+      }
+    },
+    "dmi": {
+      "bios": {
+        "release_date": "04/01/2014",
+        "vendor": "SeaBIOS",
+        "version": "1.13.0-1ubuntu1"
+      },
+      "chassis": {
+        "type": "Other"
+      },
+      "manufacturer": "QEMU",
+      "product": {
+        "name": "Standard PC (i440FX + PIIX, 1996)"
+      }
+    },
+    "facterversion": "3.14.14",
+    "filesystems": "ext2,ext3,ext4",
+    "fips_enabled": false,
+    "fqdn": "localhost",
+    "gid": "vagrant",
+    "hardwareisa": "unknown",
+    "hardwaremodel": "x86_64",
+    "hostname": "buster",
+    "hypervisors": {
+      "kvm": {
+      }
+    },
+    "id": "vagrant",
+    "identity": {
+      "gid": 1000,
+      "group": "vagrant",
+      "privileged": false,
+      "uid": 1000,
+      "user": "vagrant"
+    },
+    "interfaces": "ens5,lo",
+    "ipaddress": "192.168.121.72",
+    "ipaddress6": "fe80::5054:ff:fe88:49a2",
+    "ipaddress6_ens5": "fe80::5054:ff:fe88:49a2",
+    "ipaddress6_lo": "::1",
+    "ipaddress_ens5": "192.168.121.72",
+    "ipaddress_lo": "127.0.0.1",
+    "is_virtual": true,
+    "kernel": "Linux",
+    "kernelmajversion": "4.19",
+    "kernelrelease": "4.19.0-9-amd64",
+    "kernelversion": "4.19.0",
+    "load_averages": {
+      "15m": 0.01,
+      "1m": 0.08,
+      "5m": 0.03
+    },
+    "lsbdistcodename": "buster",
+    "lsbdistdescription": "Debian GNU/Linux 10 (buster)",
+    "lsbdistid": "Debian",
+    "lsbdistrelease": "10.4",
+    "lsbmajdistrelease": "10",
+    "lsbminordistrelease": "4",
+    "macaddress": "52:54:00:88:49:a2",
+    "macaddress_ens5": "52:54:00:88:49:a2",
+    "manufacturer": "QEMU",
+    "memory": {
+      "system": {
+        "available": "289.72 MiB",
+        "available_bytes": 303792128,
+        "capacity": "40.04%",
+        "total": "483.20 MiB",
+        "total_bytes": 506667008,
+        "used": "193.48 MiB",
+        "used_bytes": 202874880
+      }
+    },
+    "memoryfree": "289.72 MiB",
+    "memoryfree_mb": 289.71875,
+    "memorysize": "483.20 MiB",
+    "memorysize_mb": 483.1953125,
+    "mountpoints": {
+      "/": {
+        "available": "16.20 GiB",
+        "available_bytes": 17397014528,
+        "capacity": "6.13%",
+        "device": "/dev/vda1",
+        "filesystem": "ext4",
+        "options": [
+          "rw",
+          "relatime",
+          "errors=remount-ro"
+        ],
+        "size": "18.21 GiB",
+        "size_bytes": 19550347264,
+        "used": "1.06 GiB",
+        "used_bytes": 1136635904
+      },
+      "/dev": {
+        "available": "227.57 MiB",
+        "available_bytes": 238620672,
+        "capacity": "0%",
+        "device": "udev",
+        "filesystem": "devtmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "relatime",
+          "size=233028k",
+          "nr_inodes=58257",
+          "mode=755"
+        ],
+        "size": "227.57 MiB",
+        "size_bytes": 238620672,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/hugepages": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "hugetlbfs",
+        "filesystem": "hugetlbfs",
+        "options": [
+          "rw",
+          "relatime",
+          "pagesize=2M"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/mqueue": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "mqueue",
+        "filesystem": "mqueue",
+        "options": [
+          "rw",
+          "relatime"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/pts": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "devpts",
+        "filesystem": "devpts",
+        "options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/shm": {
+        "available": "241.60 MiB",
+        "available_bytes": 253333504,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "nodev"
+        ],
+        "size": "241.60 MiB",
+        "size_bytes": 253333504,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/run": {
+        "available": "46.75 MiB",
+        "available_bytes": 49016832,
+        "capacity": "3.26%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "size=49480k",
+          "mode=755"
+        ],
+        "size": "48.32 MiB",
+        "size_bytes": 50667520,
+        "used": "1.57 MiB",
+        "used_bytes": 1650688
+      },
+      "/run/lock": {
+        "available": "5.00 MiB",
+        "available_bytes": 5242880,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=5120k"
+        ],
+        "size": "5.00 MiB",
+        "size_bytes": 5242880,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/run/user/1000": {
+        "available": "48.32 MiB",
+        "available_bytes": 50663424,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "size=49476k",
+          "mode=700",
+          "uid=1000",
+          "gid=1000"
+        ],
+        "size": "48.32 MiB",
+        "size_bytes": 50663424,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/sys/fs/cgroup": {
+        "available": "241.60 MiB",
+        "available_bytes": 253333504,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "mode=755"
+        ],
+        "size": "241.60 MiB",
+        "size_bytes": 253333504,
+        "used": "0 bytes",
+        "used_bytes": 0
+      }
+    },
+    "mtu_ens5": 1500,
+    "mtu_lo": 65536,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "netmask6_ens5": "ffff:ffff:ffff:ffff::",
+    "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+    "netmask_ens5": "255.255.255.0",
+    "netmask_lo": "255.0.0.0",
+    "network": "192.168.121.0",
+    "network6": "fe80::",
+    "network6_ens5": "fe80::",
+    "network6_lo": "::1",
+    "network_ens5": "192.168.121.0",
+    "network_lo": "127.0.0.0",
+    "networking": {
+      "dhcp": "192.168.121.1",
+      "fqdn": "localhost",
+      "hostname": "buster",
+      "interfaces": {
+        "ens5": {
+          "bindings": [
+            {
+              "address": "192.168.121.72",
+              "netmask": "255.255.255.0",
+              "network": "192.168.121.0"
+            }
+          ],
+          "bindings6": [
+            {
+              "address": "fe80::5054:ff:fe88:49a2",
+              "netmask": "ffff:ffff:ffff:ffff::",
+              "network": "fe80::"
+            }
+          ],
+          "dhcp": "192.168.121.1",
+          "ip": "192.168.121.72",
+          "ip6": "fe80::5054:ff:fe88:49a2",
+          "mac": "52:54:00:88:49:a2",
+          "mtu": 1500,
+          "netmask": "255.255.255.0",
+          "netmask6": "ffff:ffff:ffff:ffff::",
+          "network": "192.168.121.0",
+          "network6": "fe80::",
+          "scope6": "link"
+        },
+        "lo": {
+          "bindings": [
+            {
+              "address": "127.0.0.1",
+              "netmask": "255.0.0.0",
+              "network": "127.0.0.0"
+            }
+          ],
+          "bindings6": [
+            {
+              "address": "::1",
+              "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+              "network": "::1"
+            }
+          ],
+          "ip": "127.0.0.1",
+          "ip6": "::1",
+          "mtu": 65536,
+          "netmask": "255.0.0.0",
+          "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+          "network": "127.0.0.0",
+          "network6": "::1",
+          "scope6": "host"
+        }
+      },
+      "ip": "192.168.121.72",
+      "ip6": "fe80::5054:ff:fe88:49a2",
+      "mac": "52:54:00:88:49:a2",
+      "mtu": 1500,
+      "netmask": "255.255.255.0",
+      "netmask6": "ffff:ffff:ffff:ffff::",
+      "network": "192.168.121.0",
+      "network6": "fe80::",
+      "primary": "ens5",
+      "scope6": "link"
+    },
+    "operatingsystem": "Debian",
+    "operatingsystemmajrelease": "10",
+    "operatingsystemrelease": "10.4",
+    "os": {
+      "architecture": "amd64",
+      "distro": {
+        "codename": "buster",
+        "description": "Debian GNU/Linux 10 (buster)",
+        "id": "Debian",
+        "release": {
+          "full": "10.4",
+          "major": "10",
+          "minor": "4"
+        }
+      },
+      "family": "Debian",
+      "hardware": "x86_64",
+      "name": "Debian",
+      "release": {
+        "full": "10.4",
+        "major": "10",
+        "minor": "4"
+      },
+      "selinux": {
+        "enabled": false
+      }
+    },
+    "osfamily": "Debian",
+    "partitions": {
+      "/dev/vda1": {
+        "mount": "/",
+        "size": "18.63 GiB",
+        "size_bytes": 19998441472
+      }
+    },
+    "path": "/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:/opt/puppetlabs/bin:/usr/sbin:/sbin",
+    "physicalprocessorcount": 1,
+    "processor0": "AMD EPYC-Rome Processor",
+    "processorcount": 1,
+    "processors": {
+      "count": 1,
+      "isa": "unknown",
+      "models": [
+        "AMD EPYC-Rome Processor"
+      ],
+      "physicalcount": 1
+    },
+    "productname": "Standard PC (i440FX + PIIX, 1996)",
+    "puppetversion": "6.19.1",
+    "ruby": {
+      "platform": "x86_64-linux",
+      "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
+      "version": "2.5.8"
+    },
+    "rubyplatform": "x86_64-linux",
+    "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
+    "rubyversion": "2.5.8",
+    "scope6": "link",
+    "scope6_ens5": "link",
+    "scope6_lo": "host",
+    "selinux": false,
+    "ssh": {
+      "ecdsa": {
+        "fingerprints": {
+          "sha1": "SSHFP 3 1 b42a0206d9f3e7a5af8fe74c52aa8deb0246311b",
+          "sha256": "SSHFP 3 2 b941abe135d0fd4b529b8a64ec8e69957c249873d7104f54e14d43fc0270f1b5"
+        },
+        "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCnAsP0kgyFNxjHAHbm8FWFjyZCnnzbYv2bDn+5Nre0Byq83ObNcIvtQwveTqvXGAqNfT2GjLdovby2zq1yJpkI=",
+        "type": "ecdsa-sha2-nistp256"
+      },
+      "ed25519": {
+        "fingerprints": {
+          "sha1": "SSHFP 4 1 4460b6b2b862be9fc2b74982ab7eb6bf59d023cf",
+          "sha256": "SSHFP 4 2 48ccb96d5cc2dc6c9e0d197c642bb25da77eb231a57259ee297760b9fa4bfc39"
+        },
+        "key": "AAAAC3NzaC1lZDI1NTE5AAAAIL397Wi4k2iiEaBr9yRnfxeW7r2pTIHlpSowZeWCNEfB",
+        "type": "ssh-ed25519"
+      },
+      "rsa": {
+        "fingerprints": {
+          "sha1": "SSHFP 1 1 a3c5c7eb200a59d18f0b23c3c52bc2d443b4c34c",
+          "sha256": "SSHFP 1 2 b27e438e1cb0569386f0423c5718f2a9fca78734f69887fee0e83371eb6d3c5d"
+        },
+        "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCn5di3FxsIrYFI//j0keOPMrlg6xxCbsTmEnGBvOgrIBwfjujiagldtz5gUShBD1kVqH+YVND8csppLqTMSIAJMUKQF5ZXYFp6S/qVZ6pCWlRn9ygu3oRpgFmhy41k8hjDZqCa9q2MEl1YSlxKjt6deEis1IM5YYzb7ulqIZ9eHMzAEUN0K/ZONfwuaDzIblypYV5pSICAa4sMtcCaY4tPvstK4GPKJ/jSbcVvMfpVs7o0wXOAocVExKzLT5Xam0xVF9tsY7APFiFhG5ouk/ZXaCi1yoqedeGZq3IDiVUVJ9WQbHv63WiUZ/v9oPDCHOnOjf05Sm5T4tI64ZaWjSPf",
+        "type": "ssh-rsa"
+      }
+    },
+    "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCnAsP0kgyFNxjHAHbm8FWFjyZCnnzbYv2bDn+5Nre0Byq83ObNcIvtQwveTqvXGAqNfT2GjLdovby2zq1yJpkI=",
+    "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIL397Wi4k2iiEaBr9yRnfxeW7r2pTIHlpSowZeWCNEfB",
+    "sshfp_ecdsa": "SSHFP 3 1 b42a0206d9f3e7a5af8fe74c52aa8deb0246311b\nSSHFP 3 2 b941abe135d0fd4b529b8a64ec8e69957c249873d7104f54e14d43fc0270f1b5",
+    "sshfp_ed25519": "SSHFP 4 1 4460b6b2b862be9fc2b74982ab7eb6bf59d023cf\nSSHFP 4 2 48ccb96d5cc2dc6c9e0d197c642bb25da77eb231a57259ee297760b9fa4bfc39",
+    "sshfp_rsa": "SSHFP 1 1 a3c5c7eb200a59d18f0b23c3c52bc2d443b4c34c\nSSHFP 1 2 b27e438e1cb0569386f0423c5718f2a9fca78734f69887fee0e83371eb6d3c5d",
+    "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCn5di3FxsIrYFI//j0keOPMrlg6xxCbsTmEnGBvOgrIBwfjujiagldtz5gUShBD1kVqH+YVND8csppLqTMSIAJMUKQF5ZXYFp6S/qVZ6pCWlRn9ygu3oRpgFmhy41k8hjDZqCa9q2MEl1YSlxKjt6deEis1IM5YYzb7ulqIZ9eHMzAEUN0K/ZONfwuaDzIblypYV5pSICAa4sMtcCaY4tPvstK4GPKJ/jSbcVvMfpVs7o0wXOAocVExKzLT5Xam0xVF9tsY7APFiFhG5ouk/ZXaCi1yoqedeGZq3IDiVUVJ9WQbHv63WiUZ/v9oPDCHOnOjf05Sm5T4tI64ZaWjSPf",
+    "system_uptime": {
+      "days": 0,
+      "hours": 0,
+      "seconds": 78,
+      "uptime": "0:01 hours"
+    },
+    "timezone": "UTC",
+    "uptime": "0:01 hours",
+    "uptime_days": 0,
+    "uptime_hours": 0,
+    "uptime_seconds": 78,
+    "virtual": "kvm",
+    "clientcert": "buster",
+    "clientversion": "6.19.1",
+    "clientnoop": false
+  },
+  "timestamp": "2021-01-01T02:16:21.197378737+00:00",
+  "expiration": "2021-01-01T02:46:21.197648839+00:00"
+}

--- a/factsets/Debian-8.11-64.json
+++ b/factsets/Debian-8.11-64.json
@@ -1,0 +1,480 @@
+{
+  "name": "jessie",
+  "values": {
+    "aio_agent_version": "6.19.1",
+    "architecture": "amd64",
+    "augeas": {
+      "version": "1.12.0"
+    },
+    "augeasversion": "1.12.0",
+    "bios_release_date": "04/01/2014",
+    "bios_vendor": "SeaBIOS",
+    "bios_version": "1.13.0-1ubuntu1",
+    "blockdevice_vda_size": 10737418240,
+    "blockdevice_vda_vendor": "0x1af4",
+    "blockdevices": "vda",
+    "chassistype": "Other",
+    "dhcp_servers": {
+      "eth0": "192.168.121.1",
+      "system": "192.168.121.1"
+    },
+    "disks": {
+      "vda": {
+        "size": "10.00 GiB",
+        "size_bytes": 10737418240,
+        "vendor": "0x1af4"
+      }
+    },
+    "dmi": {
+      "bios": {
+        "release_date": "04/01/2014",
+        "vendor": "SeaBIOS",
+        "version": "1.13.0-1ubuntu1"
+      },
+      "chassis": {
+        "type": "Other"
+      },
+      "manufacturer": "QEMU",
+      "product": {
+        "name": "Standard PC (i440FX + PIIX, 1996)"
+      }
+    },
+    "facterversion": "3.14.14",
+    "filesystems": "ext2,ext3,ext4",
+    "fips_enabled": false,
+    "fqdn": "localhost",
+    "gid": "vagrant",
+    "hardwareisa": "unknown",
+    "hardwaremodel": "x86_64",
+    "hostname": "jessie",
+    "hypervisors": {
+      "kvm": {
+      }
+    },
+    "id": "vagrant",
+    "identity": {
+      "gid": 1000,
+      "group": "vagrant",
+      "privileged": false,
+      "uid": 1000,
+      "user": "vagrant"
+    },
+    "interfaces": "eth0,lo",
+    "ipaddress": "192.168.121.6",
+    "ipaddress6": "fe80::5054:ff:fe11:6323",
+    "ipaddress6_eth0": "fe80::5054:ff:fe11:6323",
+    "ipaddress6_lo": "::1",
+    "ipaddress_eth0": "192.168.121.6",
+    "ipaddress_lo": "127.0.0.1",
+    "is_virtual": true,
+    "kernel": "Linux",
+    "kernelmajversion": "3.16",
+    "kernelrelease": "3.16.0-6-amd64",
+    "kernelversion": "3.16.0",
+    "load_averages": {
+      "15m": 0.01,
+      "1m": 0.09,
+      "5m": 0.03
+    },
+    "lsbdistcodename": "jessie",
+    "lsbdistdescription": "Debian GNU/Linux 8.11 (jessie)",
+    "lsbdistid": "Debian",
+    "lsbdistrelease": "8.11",
+    "lsbmajdistrelease": "8",
+    "lsbminordistrelease": "11",
+    "macaddress": "52:54:00:11:63:23",
+    "macaddress_eth0": "52:54:00:11:63:23",
+    "manufacturer": "QEMU",
+    "memory": {
+      "system": {
+        "available": "376.19 MiB",
+        "available_bytes": 394465280,
+        "capacity": "23.86%",
+        "total": "494.07 MiB",
+        "total_bytes": 518074368,
+        "used": "117.88 MiB",
+        "used_bytes": 123609088
+      }
+    },
+    "memoryfree": "376.19 MiB",
+    "memoryfree_mb": 376.19140625,
+    "memorysize": "494.07 MiB",
+    "memorysize_mb": 494.07421875,
+    "mountpoints": {
+      "/": {
+        "available": "7.69 GiB",
+        "available_bytes": 8261648384,
+        "capacity": "10.76%",
+        "device": "/dev/vda1",
+        "filesystem": "ext4",
+        "options": [
+          "rw",
+          "relatime",
+          "errors=remount-ro",
+          "data=ordered"
+        ],
+        "size": "9.10 GiB",
+        "size_bytes": 9773973504,
+        "used": "949.52 MiB",
+        "used_bytes": 995639296
+      },
+      "/dev": {
+        "available": "10.00 MiB",
+        "available_bytes": 10485760,
+        "capacity": "0%",
+        "device": "udev",
+        "filesystem": "devtmpfs",
+        "options": [
+          "rw",
+          "relatime",
+          "size=10240k",
+          "nr_inodes=61176",
+          "mode=755"
+        ],
+        "size": "10.00 MiB",
+        "size_bytes": 10485760,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/hugepages": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "hugetlbfs",
+        "filesystem": "hugetlbfs",
+        "options": [
+          "rw",
+          "relatime"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/mqueue": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "mqueue",
+        "filesystem": "mqueue",
+        "options": [
+          "rw",
+          "relatime"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/pts": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "devpts",
+        "filesystem": "devpts",
+        "options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/shm": {
+        "available": "247.04 MiB",
+        "available_bytes": 259035136,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "nodev"
+        ],
+        "size": "247.04 MiB",
+        "size_bytes": 259035136,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/etc/machine-id": {
+        "available": "94.55 MiB",
+        "available_bytes": 99143680,
+        "capacity": "4.32%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "ro",
+          "relatime",
+          "size=101188k",
+          "mode=755"
+        ],
+        "size": "98.82 MiB",
+        "size_bytes": 103616512,
+        "used": "4.27 MiB",
+        "used_bytes": 4472832
+      },
+      "/run": {
+        "available": "94.55 MiB",
+        "available_bytes": 99143680,
+        "capacity": "4.32%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "relatime",
+          "size=101188k",
+          "mode=755"
+        ],
+        "size": "98.82 MiB",
+        "size_bytes": 103616512,
+        "used": "4.27 MiB",
+        "used_bytes": 4472832
+      },
+      "/run/lock": {
+        "available": "5.00 MiB",
+        "available_bytes": 5242880,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=5120k"
+        ],
+        "size": "5.00 MiB",
+        "size_bytes": 5242880,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/sys/fs/cgroup": {
+        "available": "247.04 MiB",
+        "available_bytes": 259035136,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "mode=755"
+        ],
+        "size": "247.04 MiB",
+        "size_bytes": 259035136,
+        "used": "0 bytes",
+        "used_bytes": 0
+      }
+    },
+    "mtu_eth0": 1500,
+    "mtu_lo": 65536,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "netmask6_eth0": "ffff:ffff:ffff:ffff::",
+    "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+    "netmask_eth0": "255.255.255.0",
+    "netmask_lo": "255.0.0.0",
+    "network": "192.168.121.0",
+    "network6": "fe80::",
+    "network6_eth0": "fe80::",
+    "network6_lo": "::1",
+    "network_eth0": "192.168.121.0",
+    "network_lo": "127.0.0.0",
+    "networking": {
+      "dhcp": "192.168.121.1",
+      "fqdn": "localhost",
+      "hostname": "jessie",
+      "interfaces": {
+        "eth0": {
+          "bindings": [
+            {
+              "address": "192.168.121.6",
+              "netmask": "255.255.255.0",
+              "network": "192.168.121.0"
+            }
+          ],
+          "bindings6": [
+            {
+              "address": "fe80::5054:ff:fe11:6323",
+              "netmask": "ffff:ffff:ffff:ffff::",
+              "network": "fe80::"
+            }
+          ],
+          "dhcp": "192.168.121.1",
+          "ip": "192.168.121.6",
+          "ip6": "fe80::5054:ff:fe11:6323",
+          "mac": "52:54:00:11:63:23",
+          "mtu": 1500,
+          "netmask": "255.255.255.0",
+          "netmask6": "ffff:ffff:ffff:ffff::",
+          "network": "192.168.121.0",
+          "network6": "fe80::",
+          "scope6": "link"
+        },
+        "lo": {
+          "bindings": [
+            {
+              "address": "127.0.0.1",
+              "netmask": "255.0.0.0",
+              "network": "127.0.0.0"
+            }
+          ],
+          "bindings6": [
+            {
+              "address": "::1",
+              "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+              "network": "::1"
+            }
+          ],
+          "ip": "127.0.0.1",
+          "ip6": "::1",
+          "mtu": 65536,
+          "netmask": "255.0.0.0",
+          "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+          "network": "127.0.0.0",
+          "network6": "::1",
+          "scope6": "host"
+        }
+      },
+      "ip": "192.168.121.6",
+      "ip6": "fe80::5054:ff:fe11:6323",
+      "mac": "52:54:00:11:63:23",
+      "mtu": 1500,
+      "netmask": "255.255.255.0",
+      "netmask6": "ffff:ffff:ffff:ffff::",
+      "network": "192.168.121.0",
+      "network6": "fe80::",
+      "primary": "eth0",
+      "scope6": "link"
+    },
+    "operatingsystem": "Debian",
+    "operatingsystemmajrelease": "8",
+    "operatingsystemrelease": "8.11",
+    "os": {
+      "architecture": "amd64",
+      "distro": {
+        "codename": "jessie",
+        "description": "Debian GNU/Linux 8.11 (jessie)",
+        "id": "Debian",
+        "release": {
+          "full": "8.11",
+          "major": "8",
+          "minor": "11"
+        }
+      },
+      "family": "Debian",
+      "hardware": "x86_64",
+      "name": "Debian",
+      "release": {
+        "full": "8.11",
+        "major": "8",
+        "minor": "11"
+      },
+      "selinux": {
+        "enabled": false
+      }
+    },
+    "osfamily": "Debian",
+    "partitions": {
+      "/dev/vda1": {
+        "mount": "/",
+        "size": "9.31 GiB",
+        "size_bytes": 9998172160
+      }
+    },
+    "path": "/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:/opt/puppetlabs/bin:/usr/sbin:/sbin",
+    "physicalprocessorcount": 1,
+    "processor0": "AMD EPYC-Rome Processor",
+    "processorcount": 1,
+    "processors": {
+      "count": 1,
+      "isa": "unknown",
+      "models": [
+        "AMD EPYC-Rome Processor"
+      ],
+      "physicalcount": 1
+    },
+    "productname": "Standard PC (i440FX + PIIX, 1996)",
+    "puppetversion": "6.19.1",
+    "ruby": {
+      "platform": "x86_64-linux",
+      "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
+      "version": "2.5.8"
+    },
+    "rubyplatform": "x86_64-linux",
+    "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
+    "rubyversion": "2.5.8",
+    "scope6": "link",
+    "scope6_eth0": "link",
+    "scope6_lo": "host",
+    "selinux": false,
+    "ssh": {
+      "dsa": {
+        "fingerprints": {
+          "sha1": "SSHFP 2 1 a16b8da9c20ccbc0704201d5c71fbf44ba28d1ef",
+          "sha256": "SSHFP 2 2 936a3f44a4f81b2d955290cc220bdd198408ec2c5ed896a18c1dd9c9a22aea35"
+        },
+        "key": "AAAAB3NzaC1kc3MAAACBAKYlbRexnlNHr2T8VT3RCDl0jqMZj7xnu7k2ylbq9KKJitBrONwX4kbGi2XWUWk2vOj3k9WTlebzlWHTtUE8tr4UO6RFIabhrs0yuMQbpR/gwrcO833Qv/arzhAyKzUtlX/q2Uj+3xrhZqF2qDiYoBL0gKyaf9SvOT2oYHCmiBhPAAAAFQDzpxP2x6SaPF8ULUt0mWb2nP0UvQAAAIAPt4unmm3yGfjYG4bloSUKUhEg+TU8y3Med+FiwxnKln4JWg94m+/N7PhPmhjD0sw90qaDuqbM/t/lS55MUOVXGI3BEG8mWMq6EBWunkdfcF/pHfKq+nW59jWpvhaeOU+goe4uaFOhEkCpPcuj+WtADRdVZdvtQfrL24dYGC3MRwAAAIBUvecruY4qbNhaH2fPzMrmKdTTITIeCneejtjd6LRpYjK3zQDkdjWGN3a7Ge6onJVbROOVa0FNq8QpByXXSc136+W6WoSV1RmmamqisYH9fpaz/N0BUlZVwOiNtqOYUFwaHZTAY9+NmoyaZTGLY5sn9QjcEvMF6ED2WApaoC0j2w==",
+        "type": "ssh-dss"
+      },
+      "ecdsa": {
+        "fingerprints": {
+          "sha1": "SSHFP 3 1 a42dd64dc0a41bc094f3cc70ce8c113d0ba38678",
+          "sha256": "SSHFP 3 2 fd2f86be7d317a7cae022351bc02d106e7bd9d549bfc752e3e3b9f82b2464eb0"
+        },
+        "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBIte+vqELpAkmDcy1e8ZpUHHa7awBOUG2qWShoccNB1sBxiBOW/G3MRacREI1NQRb4uOUE7DHRyAfBObhx0uEvU=",
+        "type": "ecdsa-sha2-nistp256"
+      },
+      "ed25519": {
+        "fingerprints": {
+          "sha1": "SSHFP 4 1 f7d3fa8200c4d6f85876af9fd2440c8694635d2e",
+          "sha256": "SSHFP 4 2 a70f68c9951f454f79310bd1227cc09a6b0b951d17b8ac4ce006df3008c9ac1f"
+        },
+        "key": "AAAAC3NzaC1lZDI1NTE5AAAAIDwa3LLfdYOmq/dgC1x+DzeLjGWK/SR4M55v50TMLBzh",
+        "type": "ssh-ed25519"
+      },
+      "rsa": {
+        "fingerprints": {
+          "sha1": "SSHFP 1 1 dfe748320ac7c7ae524aa43f8447f933abb13beb",
+          "sha256": "SSHFP 1 2 2816b3dfc3d5bc81eaedd1afe2934a3f7dbba075c5fffd7255eb0d7ad45336ce"
+        },
+        "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDgLcDZmUNiTlFKQ/a0b6vBRRxV8qXIeiVMefdckzlcCcTjVnz3RZ/lVycEjaaVzve0ZPeFcvO7qkoBTmwinFBVD6Hxu1/i1baMdjqVdY3wlGKNRYRE/SR8SJYtYsqzL1tWHrBxkceOBTW1zbAX//oq6gElFcWUMWjkZsE5w39/VGUnfUxcxYp3t2JAPoO8ixhwYcAGS671VVft/1VvCB2vRDAd2pRgupwhbiWlOehfCZxxbB+o5WCCHUEj0HXgiyGWf5iFbjzvRdIJYI9gLZsNJKC83oEGVfoX6q5QRtYOCZRBEmS72ub7E9iO2z39Wurm7qOp/lky9jAmC4ZPDnKV",
+        "type": "ssh-rsa"
+      }
+    },
+    "sshdsakey": "AAAAB3NzaC1kc3MAAACBAKYlbRexnlNHr2T8VT3RCDl0jqMZj7xnu7k2ylbq9KKJitBrONwX4kbGi2XWUWk2vOj3k9WTlebzlWHTtUE8tr4UO6RFIabhrs0yuMQbpR/gwrcO833Qv/arzhAyKzUtlX/q2Uj+3xrhZqF2qDiYoBL0gKyaf9SvOT2oYHCmiBhPAAAAFQDzpxP2x6SaPF8ULUt0mWb2nP0UvQAAAIAPt4unmm3yGfjYG4bloSUKUhEg+TU8y3Med+FiwxnKln4JWg94m+/N7PhPmhjD0sw90qaDuqbM/t/lS55MUOVXGI3BEG8mWMq6EBWunkdfcF/pHfKq+nW59jWpvhaeOU+goe4uaFOhEkCpPcuj+WtADRdVZdvtQfrL24dYGC3MRwAAAIBUvecruY4qbNhaH2fPzMrmKdTTITIeCneejtjd6LRpYjK3zQDkdjWGN3a7Ge6onJVbROOVa0FNq8QpByXXSc136+W6WoSV1RmmamqisYH9fpaz/N0BUlZVwOiNtqOYUFwaHZTAY9+NmoyaZTGLY5sn9QjcEvMF6ED2WApaoC0j2w==",
+    "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBIte+vqELpAkmDcy1e8ZpUHHa7awBOUG2qWShoccNB1sBxiBOW/G3MRacREI1NQRb4uOUE7DHRyAfBObhx0uEvU=",
+    "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIDwa3LLfdYOmq/dgC1x+DzeLjGWK/SR4M55v50TMLBzh",
+    "sshfp_dsa": "SSHFP 2 1 a16b8da9c20ccbc0704201d5c71fbf44ba28d1ef\nSSHFP 2 2 936a3f44a4f81b2d955290cc220bdd198408ec2c5ed896a18c1dd9c9a22aea35",
+    "sshfp_ecdsa": "SSHFP 3 1 a42dd64dc0a41bc094f3cc70ce8c113d0ba38678\nSSHFP 3 2 fd2f86be7d317a7cae022351bc02d106e7bd9d549bfc752e3e3b9f82b2464eb0",
+    "sshfp_ed25519": "SSHFP 4 1 f7d3fa8200c4d6f85876af9fd2440c8694635d2e\nSSHFP 4 2 a70f68c9951f454f79310bd1227cc09a6b0b951d17b8ac4ce006df3008c9ac1f",
+    "sshfp_rsa": "SSHFP 1 1 dfe748320ac7c7ae524aa43f8447f933abb13beb\nSSHFP 1 2 2816b3dfc3d5bc81eaedd1afe2934a3f7dbba075c5fffd7255eb0d7ad45336ce",
+    "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDgLcDZmUNiTlFKQ/a0b6vBRRxV8qXIeiVMefdckzlcCcTjVnz3RZ/lVycEjaaVzve0ZPeFcvO7qkoBTmwinFBVD6Hxu1/i1baMdjqVdY3wlGKNRYRE/SR8SJYtYsqzL1tWHrBxkceOBTW1zbAX//oq6gElFcWUMWjkZsE5w39/VGUnfUxcxYp3t2JAPoO8ixhwYcAGS671VVft/1VvCB2vRDAd2pRgupwhbiWlOehfCZxxbB+o5WCCHUEj0HXgiyGWf5iFbjzvRdIJYI9gLZsNJKC83oEGVfoX6q5QRtYOCZRBEmS72ub7E9iO2z39Wurm7qOp/lky9jAmC4ZPDnKV",
+    "system_uptime": {
+      "days": 0,
+      "hours": 0,
+      "seconds": 83,
+      "uptime": "0:01 hours"
+    },
+    "timezone": "UTC",
+    "uptime": "0:01 hours",
+    "uptime_days": 0,
+    "uptime_hours": 0,
+    "uptime_seconds": 83,
+    "virtual": "kvm",
+    "clientcert": "jessie",
+    "clientversion": "6.19.1",
+    "clientnoop": false
+  },
+  "timestamp": "2021-01-01T02:09:32.844700659+00:00",
+  "expiration": "2021-01-01T02:39:32.844951509+00:00"
+}

--- a/factsets/Debian-9.12-64.json
+++ b/factsets/Debian-9.12-64.json
@@ -1,0 +1,476 @@
+{
+  "name": "stretch",
+  "values": {
+    "aio_agent_version": "6.19.1",
+    "architecture": "amd64",
+    "augeas": {
+      "version": "1.12.0"
+    },
+    "augeasversion": "1.12.0",
+    "bios_release_date": "04/01/2014",
+    "bios_vendor": "SeaBIOS",
+    "bios_version": "1.13.0-1ubuntu1",
+    "blockdevice_vda_size": 21474836480,
+    "blockdevice_vda_vendor": "0x1af4",
+    "blockdevices": "vda",
+    "chassistype": "Other",
+    "dhcp_servers": {
+      "ens5": "192.168.121.1",
+      "system": "192.168.121.1"
+    },
+    "disks": {
+      "vda": {
+        "size": "20.00 GiB",
+        "size_bytes": 21474836480,
+        "vendor": "0x1af4"
+      }
+    },
+    "dmi": {
+      "bios": {
+        "release_date": "04/01/2014",
+        "vendor": "SeaBIOS",
+        "version": "1.13.0-1ubuntu1"
+      },
+      "chassis": {
+        "type": "Other"
+      },
+      "manufacturer": "QEMU",
+      "product": {
+        "name": "Standard PC (i440FX + PIIX, 1996)"
+      }
+    },
+    "facterversion": "3.14.14",
+    "filesystems": "ext2,ext3,ext4",
+    "fips_enabled": false,
+    "fqdn": "localhost",
+    "gid": "vagrant",
+    "hardwareisa": "unknown",
+    "hardwaremodel": "x86_64",
+    "hostname": "stretch",
+    "hypervisors": {
+      "kvm": {
+      }
+    },
+    "id": "vagrant",
+    "identity": {
+      "gid": 1000,
+      "group": "vagrant",
+      "privileged": false,
+      "uid": 1000,
+      "user": "vagrant"
+    },
+    "interfaces": "ens5,lo",
+    "ipaddress": "192.168.121.233",
+    "ipaddress6": "fe80::5054:ff:feb4:48ae",
+    "ipaddress6_ens5": "fe80::5054:ff:feb4:48ae",
+    "ipaddress6_lo": "::1",
+    "ipaddress_ens5": "192.168.121.233",
+    "ipaddress_lo": "127.0.0.1",
+    "is_virtual": true,
+    "kernel": "Linux",
+    "kernelmajversion": "4.9",
+    "kernelrelease": "4.9.0-12-amd64",
+    "kernelversion": "4.9.0",
+    "load_averages": {
+      "15m": 0.02,
+      "1m": 0.24,
+      "5m": 0.07
+    },
+    "lsbdistcodename": "stretch",
+    "lsbdistdescription": "Debian GNU/Linux 9.12 (stretch)",
+    "lsbdistid": "Debian",
+    "lsbdistrelease": "9.12",
+    "lsbmajdistrelease": "9",
+    "lsbminordistrelease": "12",
+    "macaddress": "52:54:00:b4:48:ae",
+    "macaddress_ens5": "52:54:00:b4:48:ae",
+    "manufacturer": "QEMU",
+    "memory": {
+      "system": {
+        "available": "353.84 MiB",
+        "available_bytes": 371023872,
+        "capacity": "28.13%",
+        "total": "492.36 MiB",
+        "total_bytes": 516272128,
+        "used": "138.52 MiB",
+        "used_bytes": 145248256
+      }
+    },
+    "memoryfree": "353.84 MiB",
+    "memoryfree_mb": 353.8359375,
+    "memorysize": "492.36 MiB",
+    "memorysize_mb": 492.35546875,
+    "mountpoints": {
+      "/": {
+        "available": "16.31 GiB",
+        "available_bytes": 17516843008,
+        "capacity": "5.49%",
+        "device": "/dev/vda1",
+        "filesystem": "ext4",
+        "options": [
+          "rw",
+          "relatime",
+          "errors=remount-ro",
+          "data=ordered"
+        ],
+        "size": "18.21 GiB",
+        "size_bytes": 19550347264,
+        "used": "969.70 MiB",
+        "used_bytes": 1016807424
+      },
+      "/dev": {
+        "available": "235.60 MiB",
+        "available_bytes": 247042048,
+        "capacity": "0%",
+        "device": "udev",
+        "filesystem": "devtmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "relatime",
+          "size=241252k",
+          "nr_inodes=60313",
+          "mode=755"
+        ],
+        "size": "235.60 MiB",
+        "size_bytes": 247042048,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/hugepages": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "hugetlbfs",
+        "filesystem": "hugetlbfs",
+        "options": [
+          "rw",
+          "relatime"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/mqueue": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "mqueue",
+        "filesystem": "mqueue",
+        "options": [
+          "rw",
+          "relatime"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/pts": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "devpts",
+        "filesystem": "devpts",
+        "options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/shm": {
+        "available": "246.18 MiB",
+        "available_bytes": 258134016,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "nodev"
+        ],
+        "size": "246.18 MiB",
+        "size_bytes": 258134016,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/run": {
+        "available": "47.63 MiB",
+        "available_bytes": 49942528,
+        "capacity": "3.27%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "size=50420k",
+          "mode=755"
+        ],
+        "size": "49.24 MiB",
+        "size_bytes": 51630080,
+        "used": "1.61 MiB",
+        "used_bytes": 1687552
+      },
+      "/run/lock": {
+        "available": "5.00 MiB",
+        "available_bytes": 5242880,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=5120k"
+        ],
+        "size": "5.00 MiB",
+        "size_bytes": 5242880,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/run/user/1000": {
+        "available": "49.23 MiB",
+        "available_bytes": 51625984,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "size=50416k",
+          "mode=700",
+          "uid=1000",
+          "gid=1000"
+        ],
+        "size": "49.23 MiB",
+        "size_bytes": 51625984,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/sys/fs/cgroup": {
+        "available": "246.18 MiB",
+        "available_bytes": 258134016,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "mode=755"
+        ],
+        "size": "246.18 MiB",
+        "size_bytes": 258134016,
+        "used": "0 bytes",
+        "used_bytes": 0
+      }
+    },
+    "mtu_ens5": 1500,
+    "mtu_lo": 65536,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "netmask6_ens5": "ffff:ffff:ffff:ffff::",
+    "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+    "netmask_ens5": "255.255.255.0",
+    "netmask_lo": "255.0.0.0",
+    "network": "192.168.121.0",
+    "network6": "fe80::",
+    "network6_ens5": "fe80::",
+    "network6_lo": "::1",
+    "network_ens5": "192.168.121.0",
+    "network_lo": "127.0.0.0",
+    "networking": {
+      "dhcp": "192.168.121.1",
+      "fqdn": "localhost",
+      "hostname": "stretch",
+      "interfaces": {
+        "ens5": {
+          "bindings": [
+            {
+              "address": "192.168.121.233",
+              "netmask": "255.255.255.0",
+              "network": "192.168.121.0"
+            }
+          ],
+          "bindings6": [
+            {
+              "address": "fe80::5054:ff:feb4:48ae",
+              "netmask": "ffff:ffff:ffff:ffff::",
+              "network": "fe80::"
+            }
+          ],
+          "dhcp": "192.168.121.1",
+          "ip": "192.168.121.233",
+          "ip6": "fe80::5054:ff:feb4:48ae",
+          "mac": "52:54:00:b4:48:ae",
+          "mtu": 1500,
+          "netmask": "255.255.255.0",
+          "netmask6": "ffff:ffff:ffff:ffff::",
+          "network": "192.168.121.0",
+          "network6": "fe80::",
+          "scope6": "link"
+        },
+        "lo": {
+          "bindings": [
+            {
+              "address": "127.0.0.1",
+              "netmask": "255.0.0.0",
+              "network": "127.0.0.0"
+            }
+          ],
+          "bindings6": [
+            {
+              "address": "::1",
+              "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+              "network": "::1"
+            }
+          ],
+          "ip": "127.0.0.1",
+          "ip6": "::1",
+          "mtu": 65536,
+          "netmask": "255.0.0.0",
+          "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+          "network": "127.0.0.0",
+          "network6": "::1",
+          "scope6": "host"
+        }
+      },
+      "ip": "192.168.121.233",
+      "ip6": "fe80::5054:ff:feb4:48ae",
+      "mac": "52:54:00:b4:48:ae",
+      "mtu": 1500,
+      "netmask": "255.255.255.0",
+      "netmask6": "ffff:ffff:ffff:ffff::",
+      "network": "192.168.121.0",
+      "network6": "fe80::",
+      "primary": "ens5",
+      "scope6": "link"
+    },
+    "operatingsystem": "Debian",
+    "operatingsystemmajrelease": "9",
+    "operatingsystemrelease": "9.12",
+    "os": {
+      "architecture": "amd64",
+      "distro": {
+        "codename": "stretch",
+        "description": "Debian GNU/Linux 9.12 (stretch)",
+        "id": "Debian",
+        "release": {
+          "full": "9.12",
+          "major": "9",
+          "minor": "12"
+        }
+      },
+      "family": "Debian",
+      "hardware": "x86_64",
+      "name": "Debian",
+      "release": {
+        "full": "9.12",
+        "major": "9",
+        "minor": "12"
+      },
+      "selinux": {
+        "enabled": false
+      }
+    },
+    "osfamily": "Debian",
+    "partitions": {
+      "/dev/vda1": {
+        "mount": "/",
+        "size": "18.63 GiB",
+        "size_bytes": 19998441472
+      }
+    },
+    "path": "/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:/opt/puppetlabs/bin:/usr/sbin:/sbin",
+    "physicalprocessorcount": 1,
+    "processor0": "AMD EPYC-Rome Processor",
+    "processorcount": 1,
+    "processors": {
+      "count": 1,
+      "isa": "unknown",
+      "models": [
+        "AMD EPYC-Rome Processor"
+      ],
+      "physicalcount": 1
+    },
+    "productname": "Standard PC (i440FX + PIIX, 1996)",
+    "puppetversion": "6.19.1",
+    "ruby": {
+      "platform": "x86_64-linux",
+      "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
+      "version": "2.5.8"
+    },
+    "rubyplatform": "x86_64-linux",
+    "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
+    "rubyversion": "2.5.8",
+    "scope6": "link",
+    "scope6_ens5": "link",
+    "scope6_lo": "host",
+    "selinux": false,
+    "ssh": {
+      "ecdsa": {
+        "fingerprints": {
+          "sha1": "SSHFP 3 1 ff9175f4798805f6a6159babbf25fe9ba0391dad",
+          "sha256": "SSHFP 3 2 630465bbbb1ba6b7590a47b0a78e09df19239f772e440483302c2a3b3248968f"
+        },
+        "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEJjPceZG0r+a03zqVnyUA8skr8HvXARBKslsU/b2SGR1lm43NAAik5i1uctnAJkhDdfzpLrkR3ZOr93L+OWDBE=",
+        "type": "ecdsa-sha2-nistp256"
+      },
+      "ed25519": {
+        "fingerprints": {
+          "sha1": "SSHFP 4 1 a5dddd1e92ed18e5817451b706b23c624b06d5f7",
+          "sha256": "SSHFP 4 2 b487cea583a2a3c31af9b361ebcea0dc379511dae0c4bb07911c86b540d015cd"
+        },
+        "key": "AAAAC3NzaC1lZDI1NTE5AAAAIAqKFgiLtOyU1kgZugZuWjwdtyZTHTfiH+yQfat1HZSi",
+        "type": "ssh-ed25519"
+      },
+      "rsa": {
+        "fingerprints": {
+          "sha1": "SSHFP 1 1 bd2f6bb015cf5e2e1628d17eccbf220cb36b6355",
+          "sha256": "SSHFP 1 2 df108fc59283c0f45f9f90f2e47c1552c4b83c778aa391ec5f4ff24d4ca9aa46"
+        },
+        "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDeKGPHY9vMpnFL6uQ1RB65DkUk05XHpWdXmECEePuHDDCkAyT+lDIqZG8u4OrcBEPGCsSXh68/pcJa5ZJZyS9yP6a7sbyc4sinpdQxNKBRnhn+S+zJ0px5zJM/Rmb3ZozRxmGYaFvaE5AglUp05s+8MHeZZqzjhfjARuOc9CYXlk2SfMzfvu+bcltV204JoiJ97CHcDkKi95WNrpH5emLJ8mkSU7/70oGw6681ZCRINc1BqT9Bqn8FTEcGrgQBiYdjsczp54EguMPaU21AwC3Cse4xMFS7DSSdL1xrzZKqE/WArGtoNOql0rqY5baOwuFCmPSu5UTWwfDFhPUa7JRR",
+        "type": "ssh-rsa"
+      }
+    },
+    "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEJjPceZG0r+a03zqVnyUA8skr8HvXARBKslsU/b2SGR1lm43NAAik5i1uctnAJkhDdfzpLrkR3ZOr93L+OWDBE=",
+    "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIAqKFgiLtOyU1kgZugZuWjwdtyZTHTfiH+yQfat1HZSi",
+    "sshfp_ecdsa": "SSHFP 3 1 ff9175f4798805f6a6159babbf25fe9ba0391dad\nSSHFP 3 2 630465bbbb1ba6b7590a47b0a78e09df19239f772e440483302c2a3b3248968f",
+    "sshfp_ed25519": "SSHFP 4 1 a5dddd1e92ed18e5817451b706b23c624b06d5f7\nSSHFP 4 2 b487cea583a2a3c31af9b361ebcea0dc379511dae0c4bb07911c86b540d015cd",
+    "sshfp_rsa": "SSHFP 1 1 bd2f6bb015cf5e2e1628d17eccbf220cb36b6355\nSSHFP 1 2 df108fc59283c0f45f9f90f2e47c1552c4b83c778aa391ec5f4ff24d4ca9aa46",
+    "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDeKGPHY9vMpnFL6uQ1RB65DkUk05XHpWdXmECEePuHDDCkAyT+lDIqZG8u4OrcBEPGCsSXh68/pcJa5ZJZyS9yP6a7sbyc4sinpdQxNKBRnhn+S+zJ0px5zJM/Rmb3ZozRxmGYaFvaE5AglUp05s+8MHeZZqzjhfjARuOc9CYXlk2SfMzfvu+bcltV204JoiJ97CHcDkKi95WNrpH5emLJ8mkSU7/70oGw6681ZCRINc1BqT9Bqn8FTEcGrgQBiYdjsczp54EguMPaU21AwC3Cse4xMFS7DSSdL1xrzZKqE/WArGtoNOql0rqY5baOwuFCmPSu5UTWwfDFhPUa7JRR",
+    "system_uptime": {
+      "days": 0,
+      "hours": 0,
+      "seconds": 71,
+      "uptime": "0:01 hours"
+    },
+    "timezone": "UTC",
+    "uptime": "0:01 hours",
+    "uptime_days": 0,
+    "uptime_hours": 0,
+    "uptime_seconds": 71,
+    "virtual": "kvm",
+    "clientcert": "stretch",
+    "clientversion": "6.19.1",
+    "clientnoop": false
+  },
+  "timestamp": "2021-01-01T02:13:57.494595858+00:00",
+  "expiration": "2021-01-01T02:43:57.494862124+00:00"
+}

--- a/factsets/Ubuntu-20.04-64.json
+++ b/factsets/Ubuntu-20.04-64.json
@@ -1,0 +1,504 @@
+{
+  "name": "ubuntu2004.localdomain",
+  "values": {
+    "aio_agent_version": "6.19.1",
+    "architecture": "amd64",
+    "augeas": {
+      "version": "1.12.0"
+    },
+    "augeasversion": "1.12.0",
+    "bios_release_date": "04/01/2014",
+    "bios_vendor": "SeaBIOS",
+    "bios_version": "1.13.0-1ubuntu1",
+    "blockdevice_vda_size": 34359738368,
+    "blockdevice_vda_vendor": "0x1af4",
+    "blockdevices": "vda",
+    "chassistype": "Other",
+    "dhcp_servers": {
+      "eth0": "192.168.121.1",
+      "system": "192.168.121.1"
+    },
+    "disks": {
+      "vda": {
+        "size": "32.00 GiB",
+        "size_bytes": 34359738368,
+        "vendor": "0x1af4"
+      }
+    },
+    "dmi": {
+      "bios": {
+        "release_date": "04/01/2014",
+        "vendor": "SeaBIOS",
+        "version": "1.13.0-1ubuntu1"
+      },
+      "chassis": {
+        "type": "Other"
+      },
+      "manufacturer": "QEMU",
+      "product": {
+        "name": "Standard PC (i440FX + PIIX, 1996)"
+      }
+    },
+    "domain": "localdomain",
+    "facterversion": "3.14.14",
+    "filesystems": "btrfs,ext2,ext3,ext4,squashfs,vfat",
+    "fips_enabled": false,
+    "fqdn": "ubuntu2004.localdomain",
+    "gid": "vagrant",
+    "hardwareisa": "x86_64",
+    "hardwaremodel": "x86_64",
+    "hostname": "ubuntu2004",
+    "hypervisors": {
+      "kvm": {
+      }
+    },
+    "id": "vagrant",
+    "identity": {
+      "gid": 1000,
+      "group": "vagrant",
+      "privileged": false,
+      "uid": 1000,
+      "user": "vagrant"
+    },
+    "interfaces": "eth0,lo",
+    "ipaddress": "192.168.121.142",
+    "ipaddress6": "fe80::5054:ff:fe6d:cd91",
+    "ipaddress6_eth0": "fe80::5054:ff:fe6d:cd91",
+    "ipaddress_eth0": "192.168.121.142",
+    "ipaddress_lo": "127.0.0.1",
+    "is_virtual": true,
+    "kernel": "Linux",
+    "kernelmajversion": "5.4",
+    "kernelrelease": "5.4.0-26-generic",
+    "kernelversion": "5.4.0",
+    "load_averages": {
+      "15m": 0.04,
+      "1m": 0.4,
+      "5m": 0.12
+    },
+    "lsbdistcodename": "focal",
+    "lsbdistdescription": "Ubuntu 20.04 LTS",
+    "lsbdistid": "Ubuntu",
+    "lsbdistrelease": "20.04",
+    "lsbmajdistrelease": "20.04",
+    "macaddress": "52:54:00:6d:cd:91",
+    "macaddress_eth0": "52:54:00:6d:cd:91",
+    "manufacturer": "QEMU",
+    "memory": {
+      "swap": {
+        "available": "1.91 GiB",
+        "available_bytes": 2047864832,
+        "capacity": "0%",
+        "total": "1.91 GiB",
+        "total_bytes": 2047864832,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "system": {
+        "available": "1.65 GiB",
+        "available_bytes": 1767514112,
+        "capacity": "15.19%",
+        "total": "1.94 GiB",
+        "total_bytes": 2084052992,
+        "used": "301.88 MiB",
+        "used_bytes": 316538880
+      }
+    },
+    "memoryfree": "1.65 GiB",
+    "memoryfree_mb": 1685.6328125,
+    "memorysize": "1.94 GiB",
+    "memorysize_mb": 1987.5078125,
+    "mountpoints": {
+      "/": {
+        "available": "25.33 GiB",
+        "available_bytes": 27195854848,
+        "capacity": "7.99%",
+        "device": "/dev/vda3",
+        "filesystem": "ext4",
+        "options": [
+          "rw",
+          "relatime",
+          "errors=remount-ro"
+        ],
+        "size": "29.03 GiB",
+        "size_bytes": 31165706240,
+        "used": "2.20 GiB",
+        "used_bytes": 2363121664
+      },
+      "/boot": {
+        "available": "320.18 MiB",
+        "available_bytes": 335732736,
+        "capacity": "24.06%",
+        "device": "/dev/vda1",
+        "filesystem": "ext4",
+        "options": [
+          "rw",
+          "relatime"
+        ],
+        "size": "455.73 MiB",
+        "size_bytes": 477863936,
+        "used": "101.46 MiB",
+        "used_bytes": 106389504
+      },
+      "/dev": {
+        "available": "950.96 MiB",
+        "available_bytes": 997154816,
+        "capacity": "0%",
+        "device": "udev",
+        "filesystem": "devtmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "size=973784k",
+          "nr_inodes=243446",
+          "mode=755"
+        ],
+        "size": "950.96 MiB",
+        "size_bytes": 997154816,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/hugepages": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "hugetlbfs",
+        "filesystem": "hugetlbfs",
+        "options": [
+          "rw",
+          "relatime",
+          "pagesize=2M"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/mqueue": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "mqueue",
+        "filesystem": "mqueue",
+        "options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/pts": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "devpts",
+        "filesystem": "devpts",
+        "options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/shm": {
+        "available": "993.75 MiB",
+        "available_bytes": 1042026496,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "nodev"
+        ],
+        "size": "993.75 MiB",
+        "size_bytes": 1042026496,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/run": {
+        "available": "198.09 MiB",
+        "available_bytes": 207712256,
+        "capacity": "0.33%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=203524k",
+          "mode=755"
+        ],
+        "size": "198.75 MiB",
+        "size_bytes": 208408576,
+        "used": "680.00 KiB",
+        "used_bytes": 696320
+      },
+      "/run/lock": {
+        "available": "5.00 MiB",
+        "available_bytes": 5242880,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=5120k"
+        ],
+        "size": "5.00 MiB",
+        "size_bytes": 5242880,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/run/user/1000": {
+        "available": "198.75 MiB",
+        "available_bytes": 208404480,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "size=203520k",
+          "mode=700",
+          "uid=1000",
+          "gid=1000"
+        ],
+        "size": "198.75 MiB",
+        "size_bytes": 208404480,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/sys/fs/cgroup": {
+        "available": "993.75 MiB",
+        "available_bytes": 1042026496,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "mode=755"
+        ],
+        "size": "993.75 MiB",
+        "size_bytes": 1042026496,
+        "used": "0 bytes",
+        "used_bytes": 0
+      }
+    },
+    "mtu_eth0": 1500,
+    "mtu_lo": 65536,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "netmask6_eth0": "ffff:ffff:ffff:ffff::",
+    "netmask_eth0": "255.255.255.0",
+    "netmask_lo": "255.0.0.0",
+    "network": "192.168.121.0",
+    "network6": "fe80::",
+    "network6_eth0": "fe80::",
+    "network_eth0": "192.168.121.0",
+    "network_lo": "127.0.0.0",
+    "networking": {
+      "dhcp": "192.168.121.1",
+      "domain": "localdomain",
+      "fqdn": "ubuntu2004.localdomain",
+      "hostname": "ubuntu2004",
+      "interfaces": {
+        "eth0": {
+          "bindings": [
+            {
+              "address": "192.168.121.142",
+              "netmask": "255.255.255.0",
+              "network": "192.168.121.0"
+            }
+          ],
+          "bindings6": [
+            {
+              "address": "fe80::5054:ff:fe6d:cd91",
+              "netmask": "ffff:ffff:ffff:ffff::",
+              "network": "fe80::"
+            }
+          ],
+          "dhcp": "192.168.121.1",
+          "ip": "192.168.121.142",
+          "ip6": "fe80::5054:ff:fe6d:cd91",
+          "mac": "52:54:00:6d:cd:91",
+          "mtu": 1500,
+          "netmask": "255.255.255.0",
+          "netmask6": "ffff:ffff:ffff:ffff::",
+          "network": "192.168.121.0",
+          "network6": "fe80::",
+          "scope6": "link"
+        },
+        "lo": {
+          "bindings": [
+            {
+              "address": "127.0.0.1",
+              "netmask": "255.0.0.0",
+              "network": "127.0.0.0"
+            }
+          ],
+          "ip": "127.0.0.1",
+          "mtu": 65536,
+          "netmask": "255.0.0.0",
+          "network": "127.0.0.0"
+        }
+      },
+      "ip": "192.168.121.142",
+      "ip6": "fe80::5054:ff:fe6d:cd91",
+      "mac": "52:54:00:6d:cd:91",
+      "mtu": 1500,
+      "netmask": "255.255.255.0",
+      "netmask6": "ffff:ffff:ffff:ffff::",
+      "network": "192.168.121.0",
+      "network6": "fe80::",
+      "primary": "eth0",
+      "scope6": "link"
+    },
+    "operatingsystem": "Ubuntu",
+    "operatingsystemmajrelease": "20.04",
+    "operatingsystemrelease": "20.04",
+    "os": {
+      "architecture": "amd64",
+      "distro": {
+        "codename": "focal",
+        "description": "Ubuntu 20.04 LTS",
+        "id": "Ubuntu",
+        "release": {
+          "full": "20.04",
+          "major": "20.04"
+        }
+      },
+      "family": "Debian",
+      "hardware": "x86_64",
+      "name": "Ubuntu",
+      "release": {
+        "full": "20.04",
+        "major": "20.04"
+      },
+      "selinux": {
+        "enabled": false
+      }
+    },
+    "osfamily": "Debian",
+    "partitions": {
+      "/dev/vda1": {
+        "mount": "/boot",
+        "size": "487.00 MiB",
+        "size_bytes": 510656512
+      },
+      "/dev/vda2": {
+        "size": "1.91 GiB",
+        "size_bytes": 2047868928
+      },
+      "/dev/vda3": {
+        "mount": "/",
+        "size": "29.62 GiB",
+        "size_bytes": 31799115776
+      }
+    },
+    "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/opt/puppetlabs/bin",
+    "physicalprocessorcount": 2,
+    "processor0": "AMD EPYC-Rome Processor",
+    "processor1": "AMD EPYC-Rome Processor",
+    "processorcount": 2,
+    "processors": {
+      "count": 2,
+      "isa": "x86_64",
+      "models": [
+        "AMD EPYC-Rome Processor",
+        "AMD EPYC-Rome Processor"
+      ],
+      "physicalcount": 2
+    },
+    "productname": "Standard PC (i440FX + PIIX, 1996)",
+    "puppetversion": "6.19.1",
+    "ruby": {
+      "platform": "x86_64-linux",
+      "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
+      "version": "2.5.8"
+    },
+    "rubyplatform": "x86_64-linux",
+    "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
+    "rubyversion": "2.5.8",
+    "scope6": "link",
+    "scope6_eth0": "link",
+    "selinux": false,
+    "ssh": {
+      "ecdsa": {
+        "fingerprints": {
+          "sha1": "SSHFP 3 1 3cdbc9829d036228621af9645f3114cff0760e69",
+          "sha256": "SSHFP 3 2 32cfb85a014f3d3efa3fa72d75cf677daf77c1618892feba8e93e7ef6173c5a2"
+        },
+        "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHJIYISK9YDfRugBJP/+LEJCmanhCg9YxA74DYLwm/WTblLpM+k/MUNqPJXDxu5sT+kYOqH7C68FF9lM9NC5dSg=",
+        "type": "ecdsa-sha2-nistp256"
+      },
+      "ed25519": {
+        "fingerprints": {
+          "sha1": "SSHFP 4 1 42a9b0f8d11e1a58695acfd46749ef1403eb904b",
+          "sha256": "SSHFP 4 2 effe7dad56e9907490ca1cb63a6769b70dd1a84c6cf714ceaab470076f4ae7f0"
+        },
+        "key": "AAAAC3NzaC1lZDI1NTE5AAAAIBRxWv28jYu8mFiMlOtf4/hJN0I5TxL3DwpugSNKXpBO",
+        "type": "ssh-ed25519"
+      },
+      "rsa": {
+        "fingerprints": {
+          "sha1": "SSHFP 1 1 1c75dd1573135c06d394933fa53347c610fa3ad3",
+          "sha256": "SSHFP 1 2 529e0846eafbc77f8378be36c7bb4176ad480eb03bcb76a4e1110cfacbdc26a2"
+        },
+        "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC1eimOVlTMHiiW4xibM5Fw3EGQuybWJCORSaWZSbEtbJYW0JF5xqArcNTd54lpky7Qn4xcEcGbsW91PcbUY8a5ksgVaI0lQAdYUGBx4ignY1nojmgeDP2LqLIesKvqf4/HFRPlDlh5Pa7vsfzGcblU9CIUMG0hs1EVheLe5EHlJvSUlT47iHkkhuglBLC30rOE9XXIHSiNN95E2+E2UTCV56oyGLJYZrmK/uz2LiC3sJzwo9Ooa4FMx1TG1CyX8w+loUc1BbN0sSFrU5HhcsHfvR8+/tJGYu5wa1Lfak6+pghivY6F/BsWXm59uL5YiBJtyOkBZjCuNy4+r3lsifV7ijxPJiAYMOs7TmU1hMZKNNnO15VAUBUSCr+PQtBMFe9GzXd08Rkf2FSOCEgAKBoyDnPAmX+G5xMb0UAK0qHK9Fnh2Pli31yzUUEuMphVX457TOt5THJVwRKnqWwosoUD3Pt5vi3hMZJY2vRQDsZ0s6KjJ41Dc6HtzGPoOD436Ec=",
+        "type": "ssh-rsa"
+      }
+    },
+    "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHJIYISK9YDfRugBJP/+LEJCmanhCg9YxA74DYLwm/WTblLpM+k/MUNqPJXDxu5sT+kYOqH7C68FF9lM9NC5dSg=",
+    "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIBRxWv28jYu8mFiMlOtf4/hJN0I5TxL3DwpugSNKXpBO",
+    "sshfp_ecdsa": "SSHFP 3 1 3cdbc9829d036228621af9645f3114cff0760e69\nSSHFP 3 2 32cfb85a014f3d3efa3fa72d75cf677daf77c1618892feba8e93e7ef6173c5a2",
+    "sshfp_ed25519": "SSHFP 4 1 42a9b0f8d11e1a58695acfd46749ef1403eb904b\nSSHFP 4 2 effe7dad56e9907490ca1cb63a6769b70dd1a84c6cf714ceaab470076f4ae7f0",
+    "sshfp_rsa": "SSHFP 1 1 1c75dd1573135c06d394933fa53347c610fa3ad3\nSSHFP 1 2 529e0846eafbc77f8378be36c7bb4176ad480eb03bcb76a4e1110cfacbdc26a2",
+    "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC1eimOVlTMHiiW4xibM5Fw3EGQuybWJCORSaWZSbEtbJYW0JF5xqArcNTd54lpky7Qn4xcEcGbsW91PcbUY8a5ksgVaI0lQAdYUGBx4ignY1nojmgeDP2LqLIesKvqf4/HFRPlDlh5Pa7vsfzGcblU9CIUMG0hs1EVheLe5EHlJvSUlT47iHkkhuglBLC30rOE9XXIHSiNN95E2+E2UTCV56oyGLJYZrmK/uz2LiC3sJzwo9Ooa4FMx1TG1CyX8w+loUc1BbN0sSFrU5HhcsHfvR8+/tJGYu5wa1Lfak6+pghivY6F/BsWXm59uL5YiBJtyOkBZjCuNy4+r3lsifV7ijxPJiAYMOs7TmU1hMZKNNnO15VAUBUSCr+PQtBMFe9GzXd08Rkf2FSOCEgAKBoyDnPAmX+G5xMb0UAK0qHK9Fnh2Pli31yzUUEuMphVX457TOt5THJVwRKnqWwosoUD3Pt5vi3hMZJY2vRQDsZ0s6KjJ41Dc6HtzGPoOD436Ec=",
+    "swapfree": "1.91 GiB",
+    "swapfree_mb": 1952.99609375,
+    "swapsize": "1.91 GiB",
+    "swapsize_mb": 1952.99609375,
+    "system_uptime": {
+      "days": 0,
+      "hours": 0,
+      "seconds": 65,
+      "uptime": "0:01 hours"
+    },
+    "timezone": "UTC",
+    "uptime": "0:01 hours",
+    "uptime_days": 0,
+    "uptime_hours": 0,
+    "uptime_seconds": 65,
+    "virtual": "kvm",
+    "clientcert": "ubuntu2004.localdomain",
+    "clientversion": "6.19.1",
+    "clientnoop": false
+  },
+  "timestamp": "2021-01-01T01:40:51.571237161+00:00",
+  "expiration": "2021-01-01T02:10:51.571623312+00:00"
+}


### PR DESCRIPTION
Generated using Puppet 6 running under Vagrant and libvirt.

* CentOS 8.3.2011
* Debian 8.11, 9.12, & 10.4
* Ubuntu 20.04 focal

### Add Ubuntu 20.04 focal factset
```
vagrant init abi/ubuntu2004 \
  && vagrant up \
  && vagrant ssh
wget https://apt.puppet.com/puppet6-release-focal.deb \
  && sudo dpkg -i puppet6-release-focal.deb \
  && sudo apt-get update \
  && sudo apt-get install -y puppet-agent
/opt/puppetlabs/bin/puppet facts > /vagrant/Ubuntu-20.04-64.json
```

### Add CentOS 8.3.2011 factset
```
vagrant init centos/8 \
 && vagrant up \
 && vagrant ssh
sudo rpm -Uvh https://yum.puppet.com/puppet6-release-el-7.noarch.rpm \
  && sudo yum install -y puppet-agent
/opt/puppetlabs/bin/puppet facts > /vagrant/CentOS-8.3.2011-64.json
```