### PR TITLE
Revert manifest setting default to nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Onceover is a tool to automatically run basic tests on an entire Puppet control 
 
 It includes automatic parsing of the `Puppetfile`, `environment.conf` and others in order to stop silly mistakes ever reaching your Puppet Master!
 
-**🍺🥳 New in v3.17.1: Heaps more Windows fixes! Windows code is now more likely to compile on Non-Windows.**
+**New in v3.20.0: I've reversed the decision to have onceover use `site.pp` in the same way Puppet does. From now on your `manifest` setting in `environment.conf` will be ignored and your `site.pp` will only be used if you explicitly set the `manifest` option in the CLI or config file.**
 
 [![Build Status](https://travis-ci.com/dylanratcliffe/onceover.svg?branch=master)](https://travis-ci.com/dylanratcliffe/onceover) [![Build status](https://ci.appveyor.com/api/projects/status/2ys2ggkgln69hmyf/branch/master?svg=true)](https://ci.appveyor.com/project/dylanratcliffe/onceover/branch/master)
 

--- a/features/cache.feature
+++ b/features/cache.feature
@@ -14,7 +14,7 @@ Feature: Create and maintain a .onceover cache
     Then the cache should exist
     And the cache should contain all controlrepo files
 
-  Scenario: Runnone onnceover in the caching repo
+  Scenario: Run onceover in the caching repo
     Given control repo "caching"
     When I run onceover command "run spec --classes role::webserver"
     Then I should not see any errors

--- a/lib/onceover/controlrepo.rb
+++ b/lib/onceover/controlrepo.rb
@@ -123,11 +123,16 @@ class Onceover
       @profile_regex    = opts[:profile_regex]    ?  Regexp.new(opts[:profile_regex]) : /profile[s]?:{2}/
       @tempdir          = opts[:tempdir]          || File.expand_path('./.onceover', @root)
       $temp_modulepath  = nil
-      manifest          = opts[:manifest]         || config['manifest'] || 'manifests'
-      @manifest         = File.expand_path(manifest, @root)
       @opts             = opts
       logger.level = :debug if @opts[:debug]
       @@existing_controlrepo = self
+
+      # Set the manifest option to the fully expanded path if it's used,
+      # default to nil
+      manifest = opts[:manifest] || config['manifest'] || nil
+      if manifest
+        @manifest = File.expand_path(manifest, @root)
+      end
     end
 
 

--- a/spec/fixtures/controlrepos/caching/manifests/site.pp
+++ b/spec/fixtures/controlrepos/caching/manifests/site.pp
@@ -29,4 +29,5 @@ node default {
   # This is where you can declare classes for all nodes.
   # Example:
   #   class { 'my_class': }
+  fail('This was using the manifest setting from environment.conf')
 }


### PR DESCRIPTION
## Background

In version `3.19.0` I "fixed" the manifest setting. I had always assumed that it was working and evaluating site.pp in the same way that it usually would on a Puppetserver, however this was not the case. Turns out this had never worked and in "fixing" thus bug I actually broke lots of people's workflows.

## Proposed Solution

My proposed solution is to go back to the manifest setting defaulting to `nil` and therefore site.pp not being evaluate unless you explicitly set the setting. Because onceover handles classification for the purposes of testing and **hopefully** the only thing that people are doing in their site.pp is classification, it makes sense for them to not be mixed.

I would propose to release this in version `3.20.0` (or maybe `3.19.1`) and not to release a major version. The reason for this at that this change is not likely to break anyone's workflow. e.g.

* If a user has put in place a workaround for the changes in `3.19.0` by setting the manifest setting, this will continue to work.
* If they have simply not upgraded then `3.20.0` will also work
* If they have modified their site.pp to not cause failures it simply wont' be called anymore, meaning that it also won't fail

The only instance I can currently see of this being a breaking change is if a user has already come to rely on the changes made in `3.29.0`, which I doubt. If this is the case it cals always be worked around by just setting the manifest setting anyway.

I am looking for feedback on this proposal, especially from @neomilium @smortex @genebean 