### PR TITLE
Pin pathspec

### DIFF
--- a/onceover.gemspec
+++ b/onceover.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logging', '>= 2.0.0'
   s.add_runtime_dependency 'multi_json', '~> 1.10'
   s.add_runtime_dependency 'parallel_tests', ">= 2.0.0"
+  s.add_runtime_dependency 'pathspec', '< 1.0.0'
   s.add_runtime_dependency 'puppet', '>=4.0'
   s.add_runtime_dependency 'puppetlabs_spec_helper', ">= 0.4.0"
   s.add_runtime_dependency 'r10k', '>=2.1.0'


### PR DESCRIPTION
puppetlabs_spec_helper 2.16.0 just dropped this pin and pathspec 1.0.0
depends on ruby 2.6.

Pinning pathspec here isn't ideal, but since bundler ignores the ruby
version requirement set on a gem and only the version of ruby that ships
with Puppet 7 supports pathspec 1.0.0 this is probably the most user
friendly option.