### PR TITLE
Add `onceover run spec --fail_fast` option

### DIFF
--- a/lib/onceover/cli/run.rb
+++ b/lib/onceover/cli/run.rb
@@ -43,6 +43,7 @@ This includes deploying using r10k and running all custom tests.
             optional :p, :parallel, 'Runs spec tests in parallel. This increases speed at the cost of poorly formatted logs and irrelevant junit output.'
             optional nil, :format, 'Which RSpec formatter to use, valid options are: documentation, progress, FailureCollector, OnceoverFormatter. You also specify this multiple times', multiple: true, default: :defaults
             optional nil, :no_workarounds, 'Disables workarounds that have been added for convenience to get around common RSPec issues such as https://github.com/rodjek/rspec-puppet/issues/665'
+            optional :ff, :fail_fast, 'Abort the run after the first failure'
 
             run do |opts, args, cmd|
               repo = Onceover::Controlrepo.new(opts)

--- a/lib/onceover/runner.rb
+++ b/lib/onceover/runner.rb
@@ -85,6 +85,7 @@ class Onceover
         # NOTE: This is the way to provide options to rspec according to:
         # https://github.com/puppetlabs/puppetlabs_spec_helper/blob/master/lib/puppetlabs_spec_helper/rake_tasks.rb#L51
         ENV['CI_SPEC_OPTIONS'] = ENV['CI_SPEC_OPTIONS'].to_s + @config.filter_tags.map { |tag| " --tag #{tag}" }.join unless @config.filter_tags.nil?
+        ENV['CI_SPEC_OPTIONS'] = ENV['CI_SPEC_OPTIONS'].to_s + ' --fail-fast' if @config.fail_fast
 
         if @config.opts[:parallel]
           logger.debug "Running #{@command_prefix}rake parallel_spec from #{@repo.tempdir}"

--- a/lib/onceover/testconfig.rb
+++ b/lib/onceover/testconfig.rb
@@ -27,6 +27,7 @@ class Onceover
     attr_accessor :after_conditions
     attr_accessor :skip_r10k
     attr_accessor :force
+    attr_accessor :fail_fast
     attr_accessor :strict_variables
     attr_accessor :formatters
 
@@ -79,6 +80,7 @@ class Onceover
       @filter_nodes   = opts[:nodes]     ? [opts[:nodes].split(',')].flatten.map {|x| Onceover::Node.find(x)} : nil
       @skip_r10k      = opts[:skip_r10k] ? true : false
       @force          = opts[:force] || false
+      @fail_fast      = opts[:fail_fast] || false
 
       # Validate the mock_functions
       if @mock_functions && @mock_functions.any? { |name, details| details.has_key? 'type' }


### PR DESCRIPTION
This PR provides a simple way to run `rspec` with `--fail-fast` option.

As explained in #305, it allow to abort tests on the first test failure.