### PR TITLE
Added protective code for errors parsing with versionomy

### DIFF
--- a/lib/onceover/controlrepo.rb
+++ b/lib/onceover/controlrepo.rb
@@ -232,46 +232,61 @@ class Onceover
 
       output_array = []
       threads      = []
+      error_array  = []
+
       puppetfile.modules.each do |mod|
         threads << Thread.new do
-          row = []
-          logger.debug "Loading data for #{mod.full_name}"
-          row << mod.full_name
-          if mod.is_a?(R10K::Module::Forge)
-            row << mod.expected_version
-            row << mod.v3_module.current_release.version
+          begin
+            row = []
+            logger.debug "Loading data for #{mod.full_name}"
+            row << mod.full_name
+            if mod.is_a?(R10K::Module::Forge)
+              row << mod.expected_version
+              row << mod.v3_module.current_release.version
 
-            current = Versionomy.parse(mod.expected_version)
-            latest = Versionomy.parse(mod.v3_module.current_release.version)
-            row << if current.major < latest.major
-                     "Major".red
-                   elsif current.minor < latest.minor
-                     "Minor".yellow
-                   elsif current.tiny < latest.tiny
-                     "Tiny".green
-                   else
-                     "No".green
-                   end
+              current = Versionomy.parse(mod.expected_version)
+              latest = Versionomy.parse(mod.v3_module.current_release.version)
 
-            row << mod.v3_module.endorsement
-            superseded_by = mod.v3_module.superseded_by
-            row << (superseded_by.nil? ? '' : superseded_by[:slug])
-          else
-            row << "N/A"
-            row << "N/A"
-            row << "N/A"
-            row << "N/A"
-            row << "N/A"
+              row << if current.major < latest.major
+                      "Major".red
+                    elsif current.minor < latest.minor
+                      "Minor".yellow
+                    elsif current.tiny < latest.tiny
+                      "Tiny".green
+                    else
+                      "No".green
+                    end
+
+              row << mod.v3_module.endorsement
+              superseded_by = mod.v3_module.superseded_by
+              row << (superseded_by.nil? ? '' : superseded_by[:slug])
+            else
+              row << "N/A"
+              row << "N/A"
+              row << "N/A"
+              row << "N/A"
+              row << "N/A"
+            end
+            output_array << row
+          rescue => e
+            error = []
+            error << mod.full_name
+            error << mod.expected_version
+            error << mod.v3_module.current_release.version
+            error << e.message
+            error_array << error
+            logger.debug "Error loading module #{mod.full_name} - #{e.inspect}"
           end
-          output_array << row
         end
       end
 
       threads.map(&:join)
 
       output_array.sort_by! { |line| line[0] }
+      error_array.sort_by! { |line| line[0] } unless error_array.empty?
 
       puts Terminal::Table.new(headings: ["Full Name", "Current Version", "Latest Version", "Out of Date?", "Endorsement", "Superseded by"], rows: output_array)
+      puts Terminal::Table.new(headings: ["Issue assessing module", "Current", "Latest", "Error"], rows: error_array) unless error_array.empty?
     end
 
     def update_puppetfile


### PR DESCRIPTION
Modules with patch versions of two depth e.g. -n-n fail when parsing under versionomy.

This update is to add protective code and output and error table of modules that failed to parse correctly.

Testing can be achieved by adding the following to the Puppetfile:

mod 'dsc-networkingdsc', '8.1.0-0-1'
mod 'dsc-computermanagementdsc', '8.4.0-0-2'