### PR TITLE
Fix onceover with modern Ruby

### DIFF
--- a/lib/onceover/controlrepo.rb
+++ b/lib/onceover/controlrepo.rb
@@ -575,7 +575,7 @@ class Onceover
       else
         template = File.read(File.expand_path("./#{template_name}", template_dir))
       end
-      ERB.new(template, nil, '-').result(bind)
+      ERB.new(template, trim_mode: '-').result(bind)
     end
 
     def self.init_write_file(contents, out_file)

--- a/lib/onceover/testconfig.rb
+++ b/lib/onceover/testconfig.rb
@@ -33,7 +33,7 @@ class Onceover
 
     def initialize(file, opts = {})
       begin
-        config = YAML.safe_load(File.read(file), [Symbol])
+        config = YAML.safe_load(File.read(file), permitted_classes: [Symbol])
       rescue Errno::ENOENT
         raise "Could not find #{file}"
       rescue Psych::SyntaxError


### PR DESCRIPTION
When running onceover with a recent version of Ruby (3.1+), execution fails due to legacy constructs that got removed from Ruby.

This PR update such constructs to fix onceover with Ruby 3.1.

- Fix `YAML.safe_load` with modern Ruby
- Fix `ERB.new` with modern Ruby
