### PR TITLE
Onceover show Puppetfile - Add versionomy support for DSC module version format 

### DIFF
--- a/lib/onceover/cli/show.rb
+++ b/lib/onceover/cli/show.rb
@@ -56,7 +56,7 @@ Useful for debugging.
             summary 'Shows the current state of the puppetfile'
             description <<-DESCRIPTION
 Shows the state of the puppetfile including current versions and
-laetst versions of each module. Great for checking for updates.
+latest versions of each module. Great for checking for updates.
 To update all modules run `onceover update puppetfile`. (Hint: once
 you have done the update, run the tests to make sure nothing breaks.)
             DESCRIPTION

--- a/lib/onceover/controlrepo.rb
+++ b/lib/onceover/controlrepo.rb
@@ -281,7 +281,7 @@ class Onceover
               row << "N/A"
             end
             output_array << row
-          rescue => e
+          rescue RuntimeError => e
             error = []
             error << mod.full_name
             error << mod.expected_version

--- a/lib/onceover/controlrepo.rb
+++ b/lib/onceover/controlrepo.rb
@@ -249,8 +249,8 @@ class Onceover
               puppetforge_format = Versionomy.default_format.modified_copy do
                 field(:patchlevel_minor) do
                   recognize_number(:default_value_optional => true,
-                                  :delimiter_regexp => '-',
-                                  :default_delimiter => '-')
+                                   :delimiter_regexp => '-',
+                                   :default_delimiter => '-')
                 end
               end
 


### PR DESCRIPTION
Addresses the issue of #324 and includes error handling from #325.

When checking comparing version numbers of current and latest modules, the DSC modules have extra characters which are unhandled by the standard version format in Versionomy.

```
Error while running: #<Versionomy::Errors::ParseError: Extra characters: "-2">
```

**Summary:**
The DSC modules on Puppet forge use a version number that is currently unsupported by the standard version format in Versionomy.
When Versionomy parses the version format `8.5.0-0-2`, the `-2` suffix is considered extra_character which results in stderr. This PR proposes using a custom format to add support for the field `patchlevel_minor` via the delimiter `-`.

The standard version format supports [major, minor, tiny, patchlevel] [8, 5, 0, 0] (e.g. 8.5.0-0)
The proposed custom_format supports [major, minor, tiny, patchlevel, patchlevel_minor] [8, 5, 0, 0, 2] (e.g. 8.5.0-0-2) 

The custom format uses `-` as the delimiter for the patchlevel_minor field. Additional support could be added later for `.` or other varieties. Simply updating the regex_delimiter from (-) to (-|.) will add this support.

This PR also includes the error handling from PR #325 to handle and flag any other version exceptions that may be unsupported by Versionomy default formats.

**Testing:**
The sample puppetfile and `onceover show puppetfile`output demonstrates the benefits of the custom_format and error handling. 

- DSC modules are now supported
- Outdated Patchlevel and patchlevel_minor versions are now checked
- Errors are handled and presented in a table format without terminating the command.
- `onceover update puppetfile` can now auto correct the badly formatted versions

``` Puppet
# sample puppetfile
forge 'https://forge.puppet.com'

# Added Puppet Forge DSC Version Format
mod 'dsc-activedirectorydsc', '6.2.0-0-2' 

# Examples of unsupported formats
mod 'dsc-securitypolicydsc', '2.10.0-0.3'
mod 'dsc-computermanagementdsc', '8.5.0-0-0-0'
```

**Output: onceover show puppetfile**

- The custom_format `puppetforge_format` the modules patchlevel_minor is correctly checked assessed 
- The error handling from #325 highlights modules with unsupported version formats instead of terminating the test.

``` zsh
+------------------------+-----------------+----------------+------------------+-------------+---------------+
| Full Name              | Current Version | Latest Version | Out of Date?     | Endorsement | Superseded by |
+------------------------+-----------------+----------------+------------------+-------------+---------------+
| dsc-activedirectorydsc | 6.2.0-0-0       | 6.2.0-0-2      | PatchLevel_minor | supported   |               |
+------------------------+-----------------+----------------+------------------+-------------+---------------+
+---------------------------+---------------+------------+--------------------------+
| Issue assessing module    | Current       | Latest     | Error                    |
+---------------------------+---------------+------------+--------------------------+
| dsc-computermanagementdsc | 8.5.0-0-0-0-0 | 8.5.0-0-2  | Extra characters: "-0-0" |
| dsc-securitypolicydsc     | 2.10.0-0.3    | 2.10.0-0-5 | Extra characters: ".3"   |
+---------------------------+---------------+------------+--------------------------+
```

After `onceover update puppetfile`
All modules have been updated to the latest version, all poorly formed versions have been replaced.
``` zsh
+---------------------------+-----------------+----------------+--------------+-------------+---------------+
| Full Name                 | Current Version | Latest Version | Out of Date? | Endorsement | Superseded by |
+---------------------------+-----------------+----------------+--------------+-------------+---------------+
| dsc-activedirectorydsc    | 6.2.0-0-2       | 6.2.0-0-2      | No           | supported   |               |
| dsc-computermanagementdsc | 8.5.0-0-2       | 8.5.0-0-2      | No           | supported   |               |
| dsc-securitypolicydsc     | 2.10.0-0-5      | 2.10.0-0-5     | No           | supported   |               |
+---------------------------+-----------------+----------------+--------------+-------------+---------------+
```
