### PR TITLE
Fix compatibility with rspec-puppet 4+

### DIFF
--- a/onceover.gemspec
+++ b/onceover.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'terminal-table', '>= 1.8.0'
   s.add_runtime_dependency 'versionomy', '>= 0.5.0'
 
-  s.add_development_dependency 'cucumber', '~> 4.1'
+  s.add_development_dependency 'cucumber', '>= 4.1', '< 10.0.0'
   s.add_development_dependency 'pry', '~> 0.13.1'
   # We need to depend on rubocop <= 1.12 in order to support Ruby 2.4 (Puppet
   # 5). Once we drop support for Puppet 5 we can re-open this

--- a/onceover.gemspec
+++ b/onceover.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'r10k', '>=2.1.0'
   s.add_runtime_dependency 'rake', '>= 10.0.0'
   s.add_runtime_dependency 'rspec', '>= 3.0.0'
-  s.add_runtime_dependency 'rspec-puppet', ">= 2.4.0"
+  s.add_runtime_dependency 'rspec-puppet', ">= 2.4.0", '< 6.0.0'
   s.add_runtime_dependency 'rspec_junit_formatter', '>= 0.2.0'
   s.add_runtime_dependency 'terminal-table', '>= 1.8.0'
   s.add_runtime_dependency 'versionomy', '>= 0.5.0'

--- a/templates/spec_helper.rb.erb
+++ b/templates/spec_helper.rb.erb
@@ -19,11 +19,9 @@ RSpec.configure do |c|
   # Also add JUnit output in case people want to use that
   c.add_formatter('RSpecJUnitFormatter','<%= repo.tempdir %>/spec.xml')
 
-  c.parser                = 'future'
 <% @formatters.each do |fm| -%>
   c.formatter             = '<%= fm %>'
 <% end -%>
-  c.trusted_server_facts  = true
   c.environmentpath       = '<%= environmentpath %>'
   c.module_path           = '<%= modulepath %>'
 <% if repo.hiera_config_file_relative_path %>


### PR DESCRIPTION
These settings where used for compatibility with Puppet 7.10 and older
(Puppet 7.10 was released more than 2 years ago).  rspec-puppet 4
removed them:
https://github.com/puppetlabs/rspec-puppet/pull/73

In order to avoid this kind of accident in the future, add an upper
bound on the rspec-puppet dependency.  Version 5.0.0 is also working
with this change, so accept anything before 6.0.0.
